### PR TITLE
Load Model Checkpoints with Arbitrary Output Dimensions

### DIFF
--- a/autrainer/training/training.py
+++ b/autrainer/training/training.py
@@ -134,9 +134,9 @@ class ModularTaskTrainer:
 
         # ? Load Pretrained Model, Optimizer, and Scheduler Checkpoints
         model_checkpoint = model_config.pop("model_checkpoint", None)
-        skip_last_layer = model_config.pop("skip_last_layer", False)
         optimizer_checkpoint = model_config.pop("optimizer_checkpoint", None)
         scheduler_checkpoint = model_config.pop("scheduler_checkpoint", None)
+        skip_last_layer = model_config.pop("skip_last_layer", True)
 
         # ? Load Model
         self.output_dim = self.data.output_dim
@@ -151,7 +151,7 @@ class ModularTaskTrainer:
                 map_location="cpu",
                 weights_only=True,
             )
-            skip_last_layer = load_pretrained_model_state(
+            load_pretrained_model_state(
                 self.model,
                 state_dict,
                 skip_last_layer,
@@ -176,7 +176,7 @@ class ModularTaskTrainer:
             load_pretrained_optim_state(
                 self.optimizer,
                 state_dict,
-                skip_last_layer or not model_checkpoint,
+                skip_last_layer,
             )
 
         # ? Load Scheduler

--- a/autrainer/training/training.py
+++ b/autrainer/training/training.py
@@ -185,7 +185,7 @@ class ModularTaskTrainer:
             instance_of=torch.optim.lr_scheduler.LRScheduler,
             optimizer=self.optimizer,
         )
-        if scheduler_checkpoint:
+        if self.scheduler is not None and scheduler_checkpoint:
             self.scheduler.load_state_dict(
                 torch.load(
                     scheduler_checkpoint,
@@ -195,7 +195,6 @@ class ModularTaskTrainer:
             )
 
         # ? Create Dataloaders
-
         self.train_loader = self.data.train_loader
         self.dev_loader = self.data.dev_loader
         self.test_loader = self.data.test_loader

--- a/autrainer/training/utils.py
+++ b/autrainer/training/utils.py
@@ -1,0 +1,17 @@
+from typing import Dict, Optional
+
+
+def format_results(
+    results: Dict[str, float],
+    results_type: str,
+    training_type: str,
+    iteration: Optional[int] = None,
+) -> str:
+    s = f"{results_type} results"
+    s += f" at {training_type} {iteration}" if iteration else ""
+    s += ":\n"
+    max_key_len = max([len(k) for k in results.keys()])
+    s += "\n".join(
+        [f"{(k+':').ljust(max_key_len+1)} {v:.4f}" for k, v in results.items()]
+    )
+    return s

--- a/autrainer/training/utils.py
+++ b/autrainer/training/utils.py
@@ -1,4 +1,7 @@
+import os
 from typing import Dict, Optional
+
+import torch
 
 
 def format_results(
@@ -15,3 +18,83 @@ def format_results(
         [f"{(k+':').ljust(max_key_len+1)} {v:.4f}" for k, v in results.items()]
     )
     return s
+
+
+def load_pretrained_model_state(
+    model: torch.nn.Module,
+    state_dict: Dict[str, torch.Tensor],
+    skip_last_layer: bool = False,
+) -> bool:
+    """Load a pretrained model state dict for a model and skip the last linear
+    layer if the output dimension of the model differs or skip_last_layer is
+    True.
+
+    Args:
+        model: Model to load the state dict into.
+        state_dict: State dict to load into the model.
+        skip_last_layer: Whether to always skip the last linear layer when
+            loading the state dict, irrespective of the shape.
+            Defaults to False.
+
+    Returns:
+        True if the last linear layer was skipped, otherwise False.
+    """
+    last_linear_layer = None
+    for name, layer in model.named_modules():
+        if isinstance(layer, torch.nn.Linear):
+            last_linear_layer = name
+
+    if last_linear_layer is None:
+        raise ValueError("No linear layers found in the model.")
+
+    module_state_dict: Dict[str, torch.Tensor] = model.state_dict()
+    module_shape = module_state_dict[last_linear_layer + ".weight"].shape
+    state_dict_shape = state_dict[last_linear_layer + ".weight"].shape
+
+    if module_shape != state_dict_shape or skip_last_layer:
+        state_dict.pop(last_linear_layer + ".weight", None)
+        state_dict.pop(last_linear_layer + ".bias", None)
+        skip_last_layer = True
+
+    model.load_state_dict(state_dict, strict=False)
+    return skip_last_layer
+
+
+def load_pretrained_optim_state(
+    optim: torch.optim.Optimizer,
+    state_dict: Dict[str, torch.Tensor],
+    skip_last_layer: bool = False,
+) -> None:
+    """Load a pretrained optimizer state dict for an optimizer and skip the
+    last linear layer when loading the state dict.
+
+    Args:
+        optim: Optimizer to load the state dict into.
+        state_dict: State dict to load into the optimizer.
+        skip_last_layer: Whether to skip the last linear layer when loading
+            the state dict. Defaults to False.
+    """
+    if skip_last_layer:
+        state_len = len(state_dict["state"])
+        state_dict["state"].pop(state_len - 1, None)  # bias
+        state_dict["state"].pop(state_len - 2, None)  # weight
+
+    optim.load_state_dict(state_dict)
+
+
+def load_checkpoint(checkpoint: str) -> Dict[str, torch.Tensor]:
+    """Load a checkpoint state dict from a file.
+
+    Args:
+        checkpoint: Path to the checkpoint file.
+
+    Raises:
+        FileNotFoundError: If the checkpoint file does not exist.
+
+    Returns:
+        The model state dict.
+    """
+    # TODO: Support Hugging Face Checkpoints in the future.
+    if not os.path.isfile(checkpoint):
+        raise FileNotFoundError(f"Checkpoint file not found: {checkpoint}")
+    return torch.load(checkpoint)

--- a/docs/source/modules/models.rst
+++ b/docs/source/modules/models.rst
@@ -23,6 +23,19 @@ To avoid race conditions when using :ref:`hydra_launcher_plugins` that may run m
    The weights for all pretrained models that are provided by `autrainer` can be automatically downloaded using the
    :ref:`autrainer fetch <cli_autrainer_fetch>` CLI command or the :meth:`~autrainer.cli.fetch` CLI wrapper function.
 
+To optionally use model, optimizer, or scheduler checkpoints, the following attributes can be set in any model configuration file:
+
+* :attr:`model_checkpoint`: The path to the model checkpoint file.
+  If the output dimensions between the checkpoint and the model configuration do not match,
+  the checkpoint will be loaded without the last linear layer.
+* :attr:`optimizer_checkpoint`: The path to the optimizer checkpoint file.
+  If the output dimensions between the checkpoint and the model configuration do not match,
+  the checkpoint will be loaded without the last linear layer, similar to the model checkpoint.
+  If no model checkpoint is provided, :attr:`skip_last_layer` is automatically set to ``True``.
+* :attr:`scheduler_checkpoint`: The path to the scheduler checkpoint file.
+* :attr:`skip_last_layer`: Whether to explicitly skip loading the checkpoint of the last linear layer for both the model and optimizer.
+  This is useful when the number of output dimensions has not changed, but the last linear layer should be reinitialized.
+  
 
 Abstract Model
 --------------

--- a/docs/source/modules/models.rst
+++ b/docs/source/modules/models.rst
@@ -25,17 +25,19 @@ To avoid race conditions when using :ref:`hydra_launcher_plugins` that may run m
 
 To optionally use model, optimizer, or scheduler checkpoints, the following attributes can be set in any model configuration file:
 
-* :attr:`model_checkpoint`: The path to the model checkpoint file.
-  If the output dimensions between the checkpoint and the model configuration do not match,
-  the checkpoint will be loaded without the last linear layer.
-* :attr:`optimizer_checkpoint`: The path to the optimizer checkpoint file.
-  If the output dimensions between the checkpoint and the model configuration do not match,
-  the checkpoint will be loaded without the last linear layer, similar to the model checkpoint.
-  If no model checkpoint is provided, :attr:`skip_last_layer` is automatically set to ``True``.
-* :attr:`scheduler_checkpoint`: The path to the scheduler checkpoint file.
-* :attr:`skip_last_layer`: Whether to explicitly skip loading the checkpoint of the last linear layer for both the model and optimizer.
-  This is useful when the number of output dimensions has not changed, but the last linear layer should be reinitialized.
-  
+* :attr:`model_checkpoint`: The path to the model checkpoint file. Defaults to None.
+* :attr:`optimizer_checkpoint`: The path to the optimizer checkpoint file. Defaults to None.
+* :attr:`scheduler_checkpoint`: The path to the scheduler checkpoint file. Defaults to None.
+* :attr:`skip_last_layer`: Whether to skip loading the state of the last linear or convolutional layer.
+  When set to True, the state of the last layer (if present) is omitted from both the model and optimizer,
+  allowing for training on a different target dataset with varying output dimensions. 
+  Defaults to True.
+
+.. note::
+
+   Loading a checkpoint assumes that the model architecture is the same as the one used to create the checkpoint and
+   that the last layer of the model is specified as the final :class:`~torch.nn.Linear` or :class:`~torch.nn.modules.conv._ConvNd` module.
+   If the last layer is not the final layer in the module order, it may not be correctly identified for skipping.
 
 Abstract Model
 --------------

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -103,7 +103,8 @@ class TestCheckpointsIntegration(BaseIndividualTempDir):
 
     def test_checkpoints(self) -> None:
         autrainer.cli.create(empty=True)
-        autrainer.cli.train({"scheduler": "StepLR"})
+        with patch("sys.argv", [""]):
+            autrainer.cli.train({"scheduler": "StepLR"})
         run_dirs = [
             f
             for f in os.listdir("results/default/training")
@@ -126,13 +127,14 @@ class TestCheckpointsIntegration(BaseIndividualTempDir):
         dataset_cfg["num_targets"] = 7
         OmegaConf.save(dataset_cfg, "conf/dataset/ToyTabular-C-7.yaml")
 
-        autrainer.cli.train(
-            {
-                "dataset": "ToyTabular-C-7",
-                "model": "ToyFFNN-CKPT",
-                "scheduler": "StepLR",
-            }
-        )
+        with patch("sys.argv", [""]):
+            autrainer.cli.train(
+                {
+                    "dataset": "ToyTabular-C-7",
+                    "model": "ToyFFNN-CKPT",
+                    "scheduler": "StepLR",
+                }
+            )
         run_dirs = [
             f
             for f in os.listdir("results/default/training")

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,9 +1,12 @@
 import os
+import warnings
 
 from omegaconf import DictConfig, OmegaConf
 import pytest
+import torch
 
 import autrainer.cli
+from autrainer.models import FFNN
 
 from .utils import BaseIndividualTempDir
 
@@ -79,3 +82,67 @@ class TestCLIIntegration(BaseIndividualTempDir):
             if os.path.isdir(os.path.join("results/default/training", f))
         ]
         assert len(run_dirs) == 1, "Should have only one run directory."
+
+
+class TestCheckpointsIntegration(BaseIndividualTempDir):
+    @staticmethod
+    def _load_state(module: torch.nn.Module, name: str, subdir: str) -> None:
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=UserWarning)
+            module.load_state_dict(
+                torch.load(
+                    f"results/default/training/{name}/{subdir}/model.pt",
+                    map_location="cpu",
+                    weights_only=True,
+                )
+            )
+        module.eval()
+
+    def test_checkpoints(self) -> None:
+        autrainer.cli.create(empty=True)
+        autrainer.cli.train({"scheduler": "StepLR"})
+        run_dirs = [
+            f
+            for f in os.listdir("results/default/training")
+            if os.path.isdir(os.path.join("results/default/training", f))
+        ]
+        assert len(run_dirs) == 1, "Should have only one run directory."
+
+        autrainer.cli.show("model", "ToyFFNN", save=True)
+        model_cfg = OmegaConf.load("conf/model/ToyFFNN.yaml")
+        run_dir = f"results/default/training/{run_dirs[0]}/_best"
+        model_cfg["id"] = "ToyFFNN-CKPT"
+        model_cfg["model_checkpoint"] = f"{run_dir}/model.pt"
+        model_cfg["optimizer_checkpoint"] = f"{run_dir}/optimizer.pt"
+        model_cfg["scheduler_checkpoint"] = f"{run_dir}/scheduler.pt"
+        OmegaConf.save(model_cfg, "conf/model/ToyFFNN-CKPT.yaml")
+
+        autrainer.cli.show("dataset", "ToyTabular-C", save=True)
+        dataset_cfg = OmegaConf.load("conf/dataset/ToyTabular-C.yaml")
+        dataset_cfg["id"] = "ToyTabular-C-7"
+        dataset_cfg["num_targets"] = 7
+        OmegaConf.save(dataset_cfg, "conf/dataset/ToyTabular-C-7.yaml")
+
+        autrainer.cli.train(
+            {
+                "dataset": "ToyTabular-C-7",
+                "model": "ToyFFNN-CKPT",
+                "scheduler": "StepLR",
+            }
+        )
+        run_dirs = [
+            f
+            for f in os.listdir("results/default/training")
+            if os.path.isdir(os.path.join("results/default/training", f))
+        ]
+        assert len(run_dirs) == 2, "Should have two run directories."
+        r1 = next(r for r in run_dirs if "ToyFFNN-CKPT" not in r)
+        r2 = next(r for r in run_dirs if "ToyFFNN-CKPT" in r)
+        m1 = FFNN(10, 64, 64)
+        self._load_state(m1, r1, "_best")
+        m2 = FFNN(7, 64, 64)
+        self._load_state(m2, r2, "_initial")
+        x = torch.randn(4, 64)
+        assert torch.allclose(
+            m1.embeddings(x), m2.embeddings(x)
+        ), "Should have same embeddings."


### PR DESCRIPTION
This adds support for pretraining and subsequent finetuning on different datasets where the number of classes / the output dimension of the model differs.

If the output dimensions of the last layer found in the checkpoint and the current model differ, the weights of the last linear layer are skipped. This also applies to the optimizer state.
If both datasets (and therefore the state dict and model) share the same output dimension, `skip_last_layer: True` skips the last linear layer explicitly.

Previously, we supported a `pretrained` attribute in the  model, optimizer, and scheduler configurations.
These attributes are now all moved to the model configuration, as they should be grouped together, and are specified as follows:
- `model_checkpoint`: The path to the model checkpoint file.
  If the output dimensions between the checkpoint and the model configuration do not match,
  the checkpoint will be loaded without the last linear layer.
- `optimizer_checkpoint`: The path to the optimizer checkpoint file.
  If the output dimensions between the checkpoint and the model configuration do not match,
  the checkpoint will be loaded without the last linear layer, similar to the model checkpoint.
  If no model checkpoint is provided, :attr:`skip_last_layer` is automatically set to ``True``.
- `scheduler_checkpoint`: The path to the scheduler checkpoint file.

Also updated the docs explaining the usage of the new attributes (the old `pretrained` attribute was not mentioned) and added a simple integration test to cover loading all 3 checkpoints.