### PR TITLE
Fix README Header Image and Add Missing PyPI Links

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,5 +1,5 @@
 <div align="center">
-  <img src="docs/source/_static/logo_banner.png" alt="autrainer — A Modular and Extensible Deep Learning Toolkit for Computer Audition Tasks">
+  <img src="https://autrainer.github.io/autrainer/_images/logo_banner.png" alt="autrainer — A Modular and Extensible Deep Learning Toolkit for Computer Audition Tasks">
 </div>
 
 # autrainer

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -29,6 +29,8 @@ classifiers = [
     "Programming Language :: Python :: 3.12",
     "Operating System :: OS Independent",
 ]
+repository = "https://github.com/autrainer/autrainer"
+documentation = "https://autrainer.github.io/autrainer/"
 
 [tool.poetry.dependencies]
 python = "^3.9"


### PR DESCRIPTION
Closes #4 by adding the correct link path to the `README.md` and adding a repository and documentation link to the `pyproject.toml`.