### PR TITLE
Fix Inference with custom Classes

### DIFF
--- a/autrainer/serving/serving.py
+++ b/autrainer/serving/serving.py
@@ -1,5 +1,6 @@
 import glob
 import os
+import sys
 from typing import Any, Callable, Dict, List, Optional, Tuple, Union
 import warnings
 
@@ -57,6 +58,7 @@ class Inference:
         self._stride_length = stride_length
         self._min_length = min_length
         self._sample_rate = sample_rate
+        sys.path.append(os.getcwd())
 
         self.model = audobject.from_yaml(
             os.path.join(self._model_path, "model.yaml")

--- a/autrainer/serving/serving.py
+++ b/autrainer/serving/serving.py
@@ -15,6 +15,7 @@ from autrainer.datasets.utils import (
     AbstractFileHandler,
     AbstractTargetTransform,
 )
+from autrainer.models import AbstractModel
 from autrainer.transforms import SmartCompose
 
 
@@ -60,7 +61,7 @@ class Inference:
         self._sample_rate = sample_rate
         sys.path.append(os.getcwd())
 
-        self.model = audobject.from_yaml(
+        self.model: AbstractModel = audobject.from_yaml(
             os.path.join(self._model_path, "model.yaml")
         )
         with warnings.catch_warnings():


### PR DESCRIPTION
When using e.g. a local custom model, `autrainer inference` is unable to load the object, as the Python import path (e.g. `some_model.SomeModel`) can not be resolved by `audobject.from_yaml(...)`.

This is fixed by adding the current working directory to the path.