### PR TITLE
Run Hydra CLI Commands only in Notebook as Subprocess

### DIFF
--- a/autrainer/core/scripts/abstract_preprocess_script.py
+++ b/autrainer/core/scripts/abstract_preprocess_script.py
@@ -25,6 +25,7 @@ class AbstractPreprocessScript(AbstractScript):
         )
 
     def _override_launcher(self, args: PreprocessArgs) -> None:
+        self._pre_sys_argv = sys.argv.copy()
         if not args.cfg_launcher:
             sys.argv = sys.argv + ["hydra/launcher=basic"]
 
@@ -38,6 +39,7 @@ class AbstractPreprocessScript(AbstractScript):
 
     def _clean_up(self) -> None:
         shutil.rmtree(self.tempdir)
+        sys.argv = self._pre_sys_argv
 
     @staticmethod
     def _id_in_dict(d: dict, id: str) -> bool:

--- a/autrainer/core/scripts/command_line_error.py
+++ b/autrainer/core/scripts/command_line_error.py
@@ -1,10 +1,6 @@
 import argparse
-from functools import wraps
 import sys
-from typing import Any, Callable, NoReturn, TypeVar
-
-
-F = TypeVar("F", bound=Callable[..., Any])
+from typing import Callable, NoReturn
 
 
 class CommandLineError(Exception):
@@ -62,14 +58,3 @@ def print_help_on_error(
         raise CommandLineError(parser, message)
 
     return closure
-
-
-def catch_cli_errors(func: F) -> F:
-    @wraps(func)
-    def wrapper(*args: Any, **kwargs: Any) -> Any:
-        try:
-            return func(*args, **kwargs)
-        except CommandLineError as e:
-            print(e.message, file=sys.stderr)
-
-    return wrapper

--- a/autrainer/core/scripts/create_script.py
+++ b/autrainer/core/scripts/create_script.py
@@ -145,6 +145,9 @@ def create(
 ) -> None:
     """Create a new project with default configurations.
 
+    If called in a notebook, the function will not raise an error and print
+    the error message instead.
+
     Args:
         directories: Configuration directories to create. One or more of:
             :const:`~autrainer.core.constants.CONFIG_FOLDERS`.
@@ -155,6 +158,15 @@ def create(
             Defaults to False.
         force: Force overwrite if the configuration directory already exists.
             Defaults to False.
+
+    Raises:
+        CommandLineError: If no configuration directories are specified and
+            neither the empty nor all flags are set.
+        CommandLineError: If the empty and all flags are set at the same time.
+        CommandLineError: If the empty or all flags are set in combination with
+            configuration directories.
+        CommandLineError: If the configuration directory already exists and the
+            force flag is not set.
     """
 
     script = CreateScript()

--- a/autrainer/core/scripts/create_script.py
+++ b/autrainer/core/scripts/create_script.py
@@ -7,7 +7,8 @@ import autrainer
 from autrainer.core.constants import CONFIG_FOLDERS
 
 from .abstract_script import AbstractScript, MockParser
-from .command_line_error import CommandLineError, catch_cli_errors
+from .command_line_error import CommandLineError
+from .utils import catch_cli_errors
 
 
 @dataclass

--- a/autrainer/core/scripts/delete_failed_script.py
+++ b/autrainer/core/scripts/delete_failed_script.py
@@ -4,12 +4,12 @@ import shutil
 from typing import List
 
 from autrainer.core.scripts.abstract_script import MockParser
-from autrainer.core.scripts.command_line_error import catch_cli_errors
 
 from .abstract_postprocess_script import (
     AbstractPostprocessArgs,
     AbstractPostprocessScript,
 )
+from .utils import catch_cli_errors
 
 
 @dataclass

--- a/autrainer/core/scripts/delete_failed_script.py
+++ b/autrainer/core/scripts/delete_failed_script.py
@@ -87,11 +87,17 @@ def rm_failed(
 ) -> None:
     """Delete failed runs from an experiment.
 
+    If called in a notebook, the function will not raise an error and print
+    the error message instead.
+
     Args:
         results_dir: Path to grid search results directory.
         experiment_id: ID of experiment to postprocess.
         force: Force deletion of failed runs without confirmation.
             Defaults to False.
+
+    Raises:
+        CommandLineError: If the results directory or experiment ID dont exist.
     """
     script = DeleteFailedScript()
     script.parser = MockParser()

--- a/autrainer/core/scripts/delete_states_script.py
+++ b/autrainer/core/scripts/delete_states_script.py
@@ -4,12 +4,12 @@ import os
 from typing import List, Optional, Union
 
 from autrainer.core.scripts.abstract_script import MockParser
-from autrainer.core.scripts.command_line_error import catch_cli_errors
 
 from .abstract_postprocess_script import (
     AbstractPostprocessArgs,
     AbstractPostprocessScript,
 )
+from .utils import catch_cli_errors
 
 
 @dataclass

--- a/autrainer/core/scripts/delete_states_script.py
+++ b/autrainer/core/scripts/delete_states_script.py
@@ -149,12 +149,18 @@ def rm_states(
 ) -> None:
     """Delete states (.pt files) from an experiment.
 
+    If called in a notebook, the function will not raise an error and print
+    the error message instead.
+
     Args:
         results_dir: Path to grid search results directory.
         experiment_id: ID of experiment to postprocess.
         keep_best: Keep best states. Defaults to True.
         keep_runs: Runs to keep. Defaults to None.
         keep_iterations: Iterations to keep. Defaults to None.
+
+    Raises:
+        CommandLineError: If the results directory or experiment ID dont exist.
     """
     script = DeleteStatesScript()
     script.parser = MockParser()

--- a/autrainer/core/scripts/fetch_script.py
+++ b/autrainer/core/scripts/fetch_script.py
@@ -9,8 +9,7 @@ from .abstract_preprocess_script import (
     AbstractPreprocessScript,
     PreprocessArgs,
 )
-from .command_line_error import catch_cli_errors
-from .utils import run_autrainer_hydra_cmd
+from .utils import catch_cli_errors, run_hydra_cmd
 
 
 class FetchScript(AbstractPreprocessScript):
@@ -92,7 +91,7 @@ def fetch(
             search path. Defaults to None.
     """
 
-    run_autrainer_hydra_cmd(
+    run_hydra_cmd(
         "fetch -l" if cfg_launcher else "fetch",
         override_kwargs,
         config_name,

--- a/autrainer/core/scripts/group_script.py
+++ b/autrainer/core/scripts/group_script.py
@@ -4,8 +4,13 @@ from omegaconf import DictConfig, OmegaConf
 
 import autrainer
 
-from .abstract_script import AbstractScript
-from .utils import catch_cli_errors, run_hydra_cmd
+from .abstract_script import AbstractScript, MockParser
+from .utils import (
+    add_hydra_args_to_sys,
+    catch_cli_errors,
+    run_hydra_cmd,
+    running_in_notebook,
+)
 
 
 class GroupScript(AbstractScript):
@@ -62,4 +67,10 @@ def group(
             config files. If config_path is None no directory is added to the
             search path. Defaults to None.
     """
-    run_hydra_cmd("group", override_kwargs, config_name, config_path)
+    if running_in_notebook():
+        run_hydra_cmd("group", override_kwargs, config_name, config_path)
+    else:
+        add_hydra_args_to_sys(override_kwargs, config_name, config_path)
+        script = GroupScript()
+        script.parser = MockParser()
+        script.main({})

--- a/autrainer/core/scripts/group_script.py
+++ b/autrainer/core/scripts/group_script.py
@@ -5,8 +5,7 @@ from omegaconf import DictConfig, OmegaConf
 import autrainer
 
 from .abstract_script import AbstractScript
-from .command_line_error import catch_cli_errors
-from .utils import run_autrainer_hydra_cmd
+from .utils import catch_cli_errors, run_hydra_cmd
 
 
 class GroupScript(AbstractScript):
@@ -63,4 +62,4 @@ def group(
             config files. If config_path is None no directory is added to the
             search path. Defaults to None.
     """
-    run_autrainer_hydra_cmd("group", override_kwargs, config_name, config_path)
+    run_hydra_cmd("group", override_kwargs, config_name, config_path)

--- a/autrainer/core/scripts/inference_script.py
+++ b/autrainer/core/scripts/inference_script.py
@@ -355,6 +355,9 @@ def inference(
 ) -> None:
     """Perform inference on a trained model.
 
+    If called in a notebook, the function will not raise an error and print
+    the error message instead.
+
     Args:
         model: Local path to model directory or Hugging Face link of the
             format: `hf:repo_id[@revision][:subdir]#local_dir`.
@@ -390,6 +393,10 @@ def inference(
             If None, no minimum length is enforced. Defaults to None.
         sample_rate: Sample rate of audio files in Hz. Has to be specified for
             sliding window inference. Defaults to None.
+
+    Raises:
+        CommandLineError: If the model, input, or preprocessing configuration
+            does not exist, or if the device is invalid.
     """
     script = InferenceScript()
     script.parser = MockParser()

--- a/autrainer/core/scripts/inference_script.py
+++ b/autrainer/core/scripts/inference_script.py
@@ -6,7 +6,8 @@ from typing import Optional
 import autrainer
 
 from .abstract_script import AbstractScript, MockParser
-from .command_line_error import CommandLineError, catch_cli_errors
+from .command_line_error import CommandLineError
+from .utils import catch_cli_errors
 
 
 @dataclass

--- a/autrainer/core/scripts/list_script.py
+++ b/autrainer/core/scripts/list_script.py
@@ -6,7 +6,8 @@ import autrainer
 from autrainer.core.constants import CONFIG_FOLDERS
 
 from .abstract_script import AbstractScript, MockParser
-from .command_line_error import CommandLineError, catch_cli_errors
+from .command_line_error import CommandLineError
+from .utils import catch_cli_errors
 
 
 @dataclass

--- a/autrainer/core/scripts/list_script.py
+++ b/autrainer/core/scripts/list_script.py
@@ -127,12 +127,19 @@ def list_configs(
 ) -> None:
     """List local and global configurations.
 
+    If called in a notebook, the function will not raise an error and print
+    the error message instead.
+
     Args:
         directory: The directory to list configurations from. Choose from:
             :const:`~autrainer.core.constants.CONFIG_FOLDERS`.
         local_only: List local configurations only. Defaults to False.
         global_only: List global configurations only. Defaults to False.
         pattern: Glob pattern to filter configurations. Defaults to "*".
+
+    Raises:
+        CommandLineError: If the local configuration directory does not exist
+            and local_only is True.
     """
 
     script = ListScript()

--- a/autrainer/core/scripts/postprocess_script.py
+++ b/autrainer/core/scripts/postprocess_script.py
@@ -8,7 +8,8 @@ from .abstract_postprocess_script import (
     AbstractPostprocessArgs,
     AbstractPostprocessScript,
 )
-from .command_line_error import CommandLineError, catch_cli_errors
+from .command_line_error import CommandLineError
+from .utils import catch_cli_errors
 
 
 @dataclass

--- a/autrainer/core/scripts/postprocess_script.py
+++ b/autrainer/core/scripts/postprocess_script.py
@@ -101,6 +101,9 @@ def postprocess(
 ) -> None:
     """Postprocess grid search results.
 
+    If called in a notebook, the function will not raise an error and print
+    the error message instead.
+
     Args:
         results_dir: Path to grid search results directory.
         experiment_id: ID of experiment to postprocess.
@@ -108,6 +111,9 @@ def postprocess(
         aggregate: Configurations to aggregate. One or more of:
             :const:`~autrainer.core.constants.VALID_AGGREGATIONS`.
             Defaults to None.
+
+    Raises:
+        CommandLineError: If the results directory or experiment ID dont exist.
     """
     script = PostprocessScript()
     script.parser = MockParser()

--- a/autrainer/core/scripts/preprocess_script.py
+++ b/autrainer/core/scripts/preprocess_script.py
@@ -4,12 +4,18 @@ from typing import Any, List, Optional
 from omegaconf import DictConfig, OmegaConf
 
 import autrainer
+from autrainer.core.scripts.abstract_script import MockParser
 
 from .abstract_preprocess_script import (
     AbstractPreprocessScript,
     PreprocessArgs,
 )
-from .utils import catch_cli_errors, run_hydra_cmd
+from .utils import (
+    add_hydra_args_to_sys,
+    catch_cli_errors,
+    run_hydra_cmd,
+    running_in_notebook,
+)
 
 
 @dataclass
@@ -250,10 +256,19 @@ def preprocess(
             config files. If config_path is None no directory is added to the
             search path. Defaults to None.
     """
-    cmd = "preprocess"
-    if cfg_launcher:
-        cmd += " -l"
-    if silent:
-        cmd += " -s"
-    cmd += f" -n {num_workers} -p {pbar_frequency}"
-    run_hydra_cmd(cmd, override_kwargs, config_name, config_path)
+    if running_in_notebook():
+        cmd = "preprocess"
+        if cfg_launcher:
+            cmd += " -l"
+        if silent:
+            cmd += " -s"
+        cmd += f" -n {num_workers} -p {pbar_frequency}"
+        run_hydra_cmd(cmd, override_kwargs, config_name, config_path)
+
+    else:
+        add_hydra_args_to_sys(override_kwargs, config_name, config_path)
+        script = PreprocessScript()
+        script.parser = MockParser()
+        script.main(
+            PreprocessArgs(cfg_launcher, num_workers, pbar_frequency, silent)
+        )

--- a/autrainer/core/scripts/preprocess_script.py
+++ b/autrainer/core/scripts/preprocess_script.py
@@ -9,8 +9,7 @@ from .abstract_preprocess_script import (
     AbstractPreprocessScript,
     PreprocessArgs,
 )
-from .command_line_error import catch_cli_errors
-from .utils import run_autrainer_hydra_cmd
+from .utils import catch_cli_errors, run_hydra_cmd
 
 
 @dataclass
@@ -257,4 +256,4 @@ def preprocess(
     if silent:
         cmd += " -s"
     cmd += f" -n {num_workers} -p {pbar_frequency}"
-    run_autrainer_hydra_cmd(cmd, override_kwargs, config_name, config_path)
+    run_hydra_cmd(cmd, override_kwargs, config_name, config_path)

--- a/autrainer/core/scripts/show_script.py
+++ b/autrainer/core/scripts/show_script.py
@@ -8,7 +8,8 @@ import autrainer
 from autrainer.core.constants import CONFIG_FOLDERS
 
 from .abstract_script import AbstractScript, MockParser
-from .command_line_error import CommandLineError, catch_cli_errors
+from .command_line_error import CommandLineError
+from .utils import catch_cli_errors
 
 
 @dataclass

--- a/autrainer/core/scripts/show_script.py
+++ b/autrainer/core/scripts/show_script.py
@@ -121,6 +121,9 @@ def show(
 ) -> None:
     """Show and save a global configuration.
 
+    If called in a notebook, the function will not raise an error and print
+    the error message instead.
+
     Args:
         directory: The directory to list configurations from. Choose from:
             :const:`~autrainer.core.constants.CONFIG_FOLDERS`.
@@ -130,6 +133,11 @@ def show(
             Defaults to False.
         force: Force overwrite local configuration if it exists in combination
             with save=True. Defaults to False.
+
+    Raises:
+        CommandLineError: If the global configuration does not exist.
+        CommandLineError: If while saving the local configuration, the
+            configuration already exists and force is not set.
     """
     script = ShowScript()
     script.parser = MockParser()

--- a/autrainer/core/scripts/train_script.py
+++ b/autrainer/core/scripts/train_script.py
@@ -5,8 +5,7 @@ from omegaconf import DictConfig, OmegaConf
 import autrainer
 
 from .abstract_script import AbstractScript
-from .command_line_error import catch_cli_errors
-from .utils import run_autrainer_hydra_cmd
+from .utils import catch_cli_errors, run_hydra_cmd
 
 
 class TrainScript(AbstractScript):
@@ -88,4 +87,4 @@ def train(
             config files. If config_path is None no directory is added to the
             search path. Defaults to None.
     """
-    run_autrainer_hydra_cmd("train", override_kwargs, config_name, config_path)
+    run_hydra_cmd("train", override_kwargs, config_name, config_path)

--- a/autrainer/core/scripts/train_script.py
+++ b/autrainer/core/scripts/train_script.py
@@ -4,8 +4,13 @@ from omegaconf import DictConfig, OmegaConf
 
 import autrainer
 
-from .abstract_script import AbstractScript
-from .utils import catch_cli_errors, run_hydra_cmd
+from .abstract_script import AbstractScript, MockParser
+from .utils import (
+    add_hydra_args_to_sys,
+    catch_cli_errors,
+    run_hydra_cmd,
+    running_in_notebook,
+)
 
 
 class TrainScript(AbstractScript):
@@ -87,4 +92,10 @@ def train(
             config files. If config_path is None no directory is added to the
             search path. Defaults to None.
     """
-    run_hydra_cmd("train", override_kwargs, config_name, config_path)
+    if running_in_notebook():
+        run_hydra_cmd("train", override_kwargs, config_name, config_path)
+    else:
+        add_hydra_args_to_sys(override_kwargs, config_name, config_path)
+        script = TrainScript()
+        script.parser = MockParser()
+        script.main({})

--- a/autrainer/models/tdnn.py
+++ b/autrainer/models/tdnn.py
@@ -1,4 +1,5 @@
 import os
+import warnings
 
 from speechbrain.inference.classifiers import EncoderClassifier
 import torch
@@ -35,11 +36,13 @@ class TDNNFFNN(AbstractModel):
         self.dropout = dropout
         checkpoint_dir = os.path.join(torch.hub.get_dir(), "speechbrain")
         os.makedirs(checkpoint_dir, exist_ok=True)
-        tdnn = EncoderClassifier.from_hparams(
-            source="speechbrain/spkrec-ecapa-voxceleb",
-            freeze_params=False,
-            savedir=checkpoint_dir,
-        )
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore", category=FutureWarning)
+            tdnn = EncoderClassifier.from_hparams(
+                source="speechbrain/spkrec-ecapa-voxceleb",
+                freeze_params=False,
+                savedir=checkpoint_dir,
+            )
         self.backbone = tdnn.mods["embedding_model"]
         self.features = tdnn.mods["compute_features"]
         self.frontend = FFNN(

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -1,4 +1,5 @@
 import os
+from unittest.mock import patch
 
 from omegaconf import DictConfig, OmegaConf
 import pytest
@@ -59,13 +60,15 @@ class TestCLIIntegration(BaseIndividualTempDir):
 
     @staticmethod
     def _train_postprocess(capfd: pytest.CaptureFixture) -> None:
-        autrainer.cli.train()
+        with patch("sys.argv", [""]):
+            autrainer.cli.train()
         out, _ = capfd.readouterr()
         print(out)
         assert "Best results at" in out, "Should print training results."
         assert "Test results:" in out, "Should print test results."
 
-        autrainer.cli.train()
+        with patch("sys.argv", [""]):
+            autrainer.cli.train()
         out, _ = capfd.readouterr()
         assert "Filtered:" in out, "Should print skipping message."
 


### PR DESCRIPTION
Currently all CLI commands that rely on Hydra (fetch, preprocess, train, group) were called in a separate sub process.
This choice was initially made as Hydra does not support google colab / jupyter notebook environments (for ref. see: https://hydra.cc/docs/advanced/compose_api/).

However, in cases where the Python CLI wrapper is used outside of a notebook, spawning separate processes may be less efficient.
This PR checks if the current _autrainer_ command is called in a notebook, and if so spawns a sub process (as before) and if not calls the script directly.
Second, we now ONLY catch CLI usage-related errors if _autrainer_ is run in a notebook (for convenience and brevity the notebook usage resembles the CLI more closely and tries to fail gracefully) and raises exceptions otherwise.
Adjusted the CLI tests accordingly and added documentation to the wrapper functions when they raise a `CommandLineError`.

As Hydra relies on `sys.argv`, not running in a sub process means that there is some more argument management that has to be done manually.