### PR TITLE
Add Audiomentations Augmentation Wrapper

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,6 +36,7 @@ The following optional dependencies can be installed to enable additional featur
 - `tensorboard` for [TensorBoard](https://www.tensorflow.org/tensorboard) logging.
 - `opensmile` for audio feature extraction with [openSMILE](https://audeering.com/opensmile/).
 - `albumentations` for image augmentations with [Albumentations](https://albumentations.ai/).
+- `audiomentations` for audio augmentations with [audiomentations](https://github.com/iver56/audiomentations).
 - `torch-audiomentations` for audio augmentations with [torch-audiomentations](https://github.com/asteroid-team/torch-audiomentations).
 
 To install _autrainer_ with all optional dependencies, use the following command:

--- a/README.rst
+++ b/README.rst
@@ -40,6 +40,7 @@ The following optional dependencies can be installed to enable additional featur
 * :attr:`tensorboard` for `TensorBoard <https://www.tensorflow.org/tensorboard>`_ logging.
 * :attr:`opensmile` for audio feature extraction with `openSMILE <https://audeering.com/opensmile/>`_.
 * :attr:`albumentations` for image augmentations with `Albumentations <https://albumentations.ai/>`_.
+* :attr:`audiomentations` for audio augmentations with `audiomentations <https://github.com/iver56/audiomentations>`_.
 * :attr:`torch-audiomentations` for audio augmentations with `torch-audiomentations <https://github.com/asteroid-team/torch-audiomentations>`_.
 
 .. code-block:: pip
@@ -49,6 +50,7 @@ The following optional dependencies can be installed to enable additional featur
    pip install autrainer[tensorboard]
    pip install autrainer[opensmile]
    pip install autrainer[albumentations]
+   pip install autrainer[audiomentations]
    pip install autrainer[torch-audiomentations]
 
 To install `autrainer` with all optional dependencies, use the following command:

--- a/autrainer/augmentations/__init__.py
+++ b/autrainer/augmentations/__init__.py
@@ -3,6 +3,7 @@ from .augmentation_manager import AugmentationManager
 from .augmentation_pipeline import AugmentationPipeline
 from .augmentation_wrappers import (
     AlbumentationsAugmentation,
+    AudiomentationsAugmentation,
     AugmentationWrapper,
     TorchaudioAugmentation,
     TorchAudiomentationsAugmentation,
@@ -24,7 +25,7 @@ from .spectrogram_augmentations import (
 __all__ = [
     "AbstractAugmentation",
     "AlbumentationsAugmentation",
-    "TorchAudiomentationsAugmentation",
+    "AudiomentationsAugmentation",
     "AugmentationManager",
     "AugmentationPipeline",
     "AugmentationWrapper",
@@ -40,5 +41,6 @@ __all__ = [
     "TimeShift",
     "TimeWarp",
     "TorchaudioAugmentation",
+    "TorchAudiomentationsAugmentation",
     "TorchvisionAugmentation",
 ]

--- a/autrainer/augmentations/__init__.py
+++ b/autrainer/augmentations/__init__.py
@@ -3,9 +3,9 @@ from .augmentation_manager import AugmentationManager
 from .augmentation_pipeline import AugmentationPipeline
 from .augmentation_wrappers import (
     AlbumentationsAugmentation,
-    AudiomentationsAugmentation,
     AugmentationWrapper,
     TorchaudioAugmentation,
+    TorchAudiomentationsAugmentation,
     TorchvisionAugmentation,
 )
 from .choice_augmentation import Choice
@@ -24,7 +24,7 @@ from .spectrogram_augmentations import (
 __all__ = [
     "AbstractAugmentation",
     "AlbumentationsAugmentation",
-    "AudiomentationsAugmentation",
+    "TorchAudiomentationsAugmentation",
     "AugmentationManager",
     "AugmentationPipeline",
     "AugmentationWrapper",

--- a/autrainer/augmentations/augmentation_wrappers.py
+++ b/autrainer/augmentations/augmentation_wrappers.py
@@ -189,6 +189,10 @@ class AlbumentationsAugmentation(AugmentationWrapper):
         """Wrapper around albumentations transforms, which are specified by
         their class name and keyword arguments.
 
+        Albumentations operates on numpy arrays, so the input tensor is
+        converted to a numpy array before applying the augmentation, and the
+        output numpy array is converted back to a tensor.
+
         Important: While the probability of applying the augmentation is
         deterministic if the generator_seed is set, the actual augmentation
         applied is not deterministic. This is because the internal random
@@ -243,6 +247,10 @@ class AudiomentationsAugmentation(AugmentationWrapper):
     ) -> None:
         """Wrapper around audiomentations transforms, which are specified
         by their class name and keyword arguments.
+
+        Audiomentations operates on numpy arrays, so the input tensor is
+        converted to a numpy array before applying the augmentation, and the
+        output numpy array is converted back to a tensor.
 
         Important: While the probability of applying the augmentation is
         deterministic if the generator_seed is set, the actual augmentation

--- a/autrainer/augmentations/augmentation_wrappers.py
+++ b/autrainer/augmentations/augmentation_wrappers.py
@@ -15,6 +15,13 @@ except ImportError:  # pragma: no cover
     ALBUMENTATIONS_AVAILABLE = False  # pragma: no cover
 
 try:
+    import audiomentations  # noqa: F401
+
+    AUDIOMENTATIONS_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    AUDIOMENTATIONS_AVAILABLE = False  # pragma: no cover
+
+try:
     import torch_audiomentations  # noqa: F401
 
     TORCHAUDIOMENTATIONS_AVAILABLE = True
@@ -222,6 +229,66 @@ class AlbumentationsAugmentation(AugmentationWrapper):
         x = self.augmentation(image=x)["image"]
         x = torch.from_numpy(x).permute(2, 0, 1).to(device)
         return x
+
+
+class AudiomentationsAugmentation(AugmentationWrapper):
+    def __init__(
+        self,
+        name: str,
+        sample_rate: Optional[int] = None,
+        order: int = 0,
+        p: float = 1.0,
+        generator_seed: Optional[int] = None,
+        **kwargs,
+    ) -> None:
+        """Wrapper around audiomentations transforms, which are specified
+        by their class name and keyword arguments.
+
+        Important: While the probability of applying the augmentation is
+        deterministic if the generator_seed is set, the actual augmentation
+        applied is not deterministic. This is because the internal random
+        number generator of the augmentation is not seeded.
+
+        Args:
+            name: Name of the torchaudio augmentation. Must be a valid
+                audiomentations transform class name.
+            sample_rate: The sample rate of the audio data. Should be specified
+                for most audio augmentations. If None, the sample rate is not
+                passed to the augmentation. Defaults to None.
+            order: The order of the augmentation in the transformation pipeline.
+                Defaults to 0.
+            p: The probability of applying the augmentation. Defaults to 1.0.
+            generator_seed: The initial seed for the internal random number
+                generator drawing the probability. If None, the generator is
+                not seeded. Defaults to None.
+            kwargs: Keyword arguments passed to the audiomentations
+                augmentation.
+        """
+        if not AUDIOMENTATIONS_AVAILABLE:
+            raise ImportError(
+                "Audiomentations is not installed. Install the required "
+                "extras with 'pip install autrainer[audiomentations]'."
+            )  # pragma: no cover
+
+        self.name = name
+        self.sample_rate = sample_rate
+        self._aug_kwargs = {}
+        if self.sample_rate is not None:
+            self._aug_kwargs["sample_rate"] = self.sample_rate
+        super().__init__(
+            augmentation_import_path=f"audiomentations.{self.name}",
+            order=order,
+            p=p,
+            generator_seed=generator_seed,
+            pass_index=False,
+            probability_attr="p",
+            **kwargs,
+        )
+
+    def apply(self, x: torch.Tensor, index: int = None) -> torch.Tensor:
+        device = x.device
+        x = self.augmentation(x.cpu().numpy(), **self._aug_kwargs)
+        return torch.from_numpy(x).to(device)
 
 
 class TorchAudiomentationsAugmentation(AugmentationWrapper):

--- a/autrainer/augmentations/augmentation_wrappers.py
+++ b/autrainer/augmentations/augmentation_wrappers.py
@@ -17,9 +17,9 @@ except ImportError:  # pragma: no cover
 try:
     import torch_audiomentations  # noqa: F401
 
-    AUDIOMENTATIONS_AVAILABLE = True
+    TORCHAUDIOMENTATIONS_AVAILABLE = True
 except ImportError:  # pragma: no cover
-    AUDIOMENTATIONS_AVAILABLE = False  # pragma: no cover
+    TORCHAUDIOMENTATIONS_AVAILABLE = False  # pragma: no cover
 
 
 class AugmentationWrapper(AbstractAugmentation):
@@ -224,7 +224,7 @@ class AlbumentationsAugmentation(AugmentationWrapper):
         return x
 
 
-class AudiomentationsAugmentation(AugmentationWrapper):
+class TorchAudiomentationsAugmentation(AugmentationWrapper):
     def __init__(
         self,
         name: str,
@@ -255,10 +255,10 @@ class AudiomentationsAugmentation(AugmentationWrapper):
             kwargs: Keyword arguments passed to the torch_audiomentations
                 augmentation.
         """
-        if not AUDIOMENTATIONS_AVAILABLE:
+        if not TORCHAUDIOMENTATIONS_AVAILABLE:
             raise ImportError(
-                "Audiomentations is not installed. Install the required extras "
-                "with 'pip install autrainer[audiomentations]'."
+                "torch-audiomentations is not installed. Install the required "
+                "extras with 'pip install autrainer[torch-audiomentations]'."
             )  # pragma: no cover
 
         self.name = name

--- a/docs/source/modules/augmentations.rst
+++ b/docs/source/modules/augmentations.rst
@@ -93,7 +93,7 @@ Both `torch-audiomentations` and `albumentations` augmentations are optional and
          :configs: AugMix GaussianBlur RandAugment RandGrayscale RandomRotation
          :headline:
 
-.. autoclass:: autrainer.augmentations.AudiomentationsAugmentation
+.. autoclass:: autrainer.augmentations.TorchAudiomentationsAugmentation
 
    .. dropdown:: Default Configurations
 

--- a/docs/source/modules/augmentations.rst
+++ b/docs/source/modules/augmentations.rst
@@ -93,6 +93,14 @@ Both `torch-audiomentations` and `albumentations` augmentations are optional and
          :configs: AugMix GaussianBlur RandAugment RandGrayscale RandomRotation
          :headline:
 
+.. autoclass:: autrainer.augmentations.AudiomentationsAugmentation
+
+   .. dropdown:: Default Configurations
+
+      No default configurations are provided for `audiomentations` augmentations.
+      To discover the available `audiomentations` augmentations,
+      refer to the `audiomentations documentation <https://iver56.github.io/audiomentations/>`_.
+
 .. autoclass:: autrainer.augmentations.TorchAudiomentationsAugmentation
 
    .. dropdown:: Default Configurations

--- a/poetry.lock
+++ b/poetry.lock
@@ -207,6 +207,28 @@ numpy = "*"
 soundfile = ">=0.12.1"
 
 [[package]]
+name = "audiomentations"
+version = "0.37.0"
+description = "A Python library for audio data augmentation. Inspired by albumentations. Useful for machine learning."
+optional = true
+python-versions = "<=3.12,>=3.8"
+files = [
+    {file = "audiomentations-0.37.0-py3-none-any.whl", hash = "sha256:2c7b06f4268796fcaf9c66237fa3de994242b601d8a590928f679d12e211577f"},
+    {file = "audiomentations-0.37.0.tar.gz", hash = "sha256:cd8590cd5aed1c8f1c6bbfa17b2b7850e613e8a732436750b3385cdebb6d0c18"},
+]
+
+[package.dependencies]
+librosa = ">=0.8.0,<0.10.0 || >0.10.0,<0.11.0"
+numpy = ">=1.21.0,<2"
+numpy-minmax = ">=0.3.0,<1"
+numpy-rms = ">=0.4.2,<1"
+scipy = ">=1.4,<1.13"
+soxr = ">=0.3.2,<1.0.0"
+
+[package.extras]
+extras = ["cylimiter (==0.3.0)", "lameenc (>=1.2.0,<2)", "pydub (>=0.22.0,<1)", "pyloudnorm (>=0.1.0)", "pyroomacoustics (>=0.6.0)"]
+
+[[package]]
 name = "audioread"
 version = "3.0.1"
 description = "Multi-library, cross-platform audio decoding."
@@ -2354,6 +2376,120 @@ files = [
 ]
 
 [[package]]
+name = "numpy-minmax"
+version = "0.3.1"
+description = "A fast python library for finding both min and max value in a NumPy array"
+optional = true
+python-versions = "*"
+files = [
+    {file = "numpy_minmax-0.3.1-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:311cf7e8302669504fabd7ee033ce611110a1df74a506730d591b5fcc49f1913"},
+    {file = "numpy_minmax-0.3.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:4c658f948e7325f1c816c7fd6a355d937ca2c580234e3774372448a3e0074a24"},
+    {file = "numpy_minmax-0.3.1-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:67bdc7fceba8f825b99cf52d9a00c242704208497f5223b703ff59d178649ad0"},
+    {file = "numpy_minmax-0.3.1-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:8fa9b73068bacde63c3544f9f2a074cc55c0def722ee58ece256598a0053136a"},
+    {file = "numpy_minmax-0.3.1-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:abd718e7fe3e3db3052777da8c9ebae77b7f39730bdc7ec76bfb408f08f9295c"},
+    {file = "numpy_minmax-0.3.1-cp310-cp310-win_amd64.whl", hash = "sha256:4a8aeb5770429877a4eb79fca8c7c987a64dadbd4ed2289b5626257787f74075"},
+    {file = "numpy_minmax-0.3.1-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:85b8d66e444a2967fbc0b1e12bec2e5dfb072c826c9895d6a36e8bae0c407361"},
+    {file = "numpy_minmax-0.3.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d518276b6acbc11c81725f5b70b0b91878514ae168f8eecba219fdcd6298dbd0"},
+    {file = "numpy_minmax-0.3.1-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b050237c26705f67b97d0fa58df663738dcaa402ed8c6ab807c4c6e3f8beb878"},
+    {file = "numpy_minmax-0.3.1-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:afde11ae5b683ea913f902905817671f8f7ce278f10a46f04a13963d31627b1b"},
+    {file = "numpy_minmax-0.3.1-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:5d76b62368cedf5cc74b510408109c971ec21e63911594325ebb1474c2a32821"},
+    {file = "numpy_minmax-0.3.1-cp311-cp311-win_amd64.whl", hash = "sha256:d0b4e3903e3cf628b703108698c6ab5bdde85298bbeebf0404fa518dd544c8dd"},
+    {file = "numpy_minmax-0.3.1-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:ae79f8ff73a9b61ba3a9753b36d101578f825e88d2de4e771669c855d533ff25"},
+    {file = "numpy_minmax-0.3.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1b2e07ed444c11f216068b978776d5c6548c2b128d50d6a149db4619265924d6"},
+    {file = "numpy_minmax-0.3.1-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5f6db55f166f55cde0d8af3b02f30107ff46ce8786f96cbc5d0feeb863169e6d"},
+    {file = "numpy_minmax-0.3.1-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:819e0e89914bdeea007a3ebec32e8717e885e4a5c7e94adab2597be54a4e7725"},
+    {file = "numpy_minmax-0.3.1-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:421aae134bea2cfc20f21c74d753bc7269df973f4ab55ad7ef484a7c66df9290"},
+    {file = "numpy_minmax-0.3.1-cp312-cp312-win_amd64.whl", hash = "sha256:b5305f61b4ae834973c01ff637d615a697f7c74732503bf80bbde7470b2dec17"},
+    {file = "numpy_minmax-0.3.1-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:445264fa11204694e095a3139417a153105575eef1f06aae878e8e450f97cf36"},
+    {file = "numpy_minmax-0.3.1-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:47e6895f6cdb9a3924de56724a67d6b8782a7573a1b6f6eaf08511693b6d85ad"},
+    {file = "numpy_minmax-0.3.1-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:0c6a5610461658b3c2ba32124598f1f78edd876d5c855d2d5a9bacc2a2c5cd24"},
+    {file = "numpy_minmax-0.3.1-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:503805e2e0b82f64ed0a92bc87d04c9296b788276faddc0d185c5d28ee26caf5"},
+    {file = "numpy_minmax-0.3.1-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:3594d9f7b090740bc0727bf7d828a104b9a35c8d12ef446a2c5ebb566d782a3a"},
+    {file = "numpy_minmax-0.3.1-cp38-cp38-win_amd64.whl", hash = "sha256:c73c8774b841b53793120b8dbcb9c9c851c9960f7e8e18467ca8e5ea96abcf6f"},
+    {file = "numpy_minmax-0.3.1-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:5a088c3141f8d5a08e0228bff3c5d31219f9d686355ac707fc9d0ab6ceeb6271"},
+    {file = "numpy_minmax-0.3.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:5610f6276a2e71ecf94ccbc84cc5861456a8239b02954e47d35eae4f56f51591"},
+    {file = "numpy_minmax-0.3.1-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:9172dc55458617f8208a9fa452001ab789c10d98be8cf533419b4680ffa3b103"},
+    {file = "numpy_minmax-0.3.1-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:38a3291862f5b30c30537cfe1079a91792f90ee908dc70e1f6a304fb28f9f498"},
+    {file = "numpy_minmax-0.3.1-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:95616b5bff56797cdef61924894a92950b62a345e1730bd997d6a17fee576a5d"},
+    {file = "numpy_minmax-0.3.1-cp39-cp39-win_amd64.whl", hash = "sha256:6c0119ac1e19a8ceee95687e2dbd36e0b4086a042bf45079247565b1e94aa364"},
+    {file = "numpy_minmax-0.3.1-pp38-pypy38_pp73-macosx_11_0_arm64.whl", hash = "sha256:b2b1d1b7bce7a1bb8f7a9c5ba0d8ed8689b6974f9d6694f4e502aca307a4138c"},
+    {file = "numpy_minmax-0.3.1-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:bff63ab8acabba97e487f867fcb78250341e9b5676f03562b66fb51e61f5a74d"},
+    {file = "numpy_minmax-0.3.1-pp38-pypy38_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1bcfc3eb1c047b68fdbf7ca5b89d5a509b12ec30e806d265c892611cbfc96047"},
+    {file = "numpy_minmax-0.3.1-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:d57cdec9543d4e6812cdc92e347e149f825d8a9af60e79b4d9553672aa0d06c4"},
+    {file = "numpy_minmax-0.3.1-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:f17a8b8807f30b75145f28c006ce0b11630630853ad2311aa3b6de517e1bb331"},
+    {file = "numpy_minmax-0.3.1-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:8f2d0a44898fbd0e18dae7175f2dc449218f93f570e5ef757221928c128b25d4"},
+    {file = "numpy_minmax-0.3.1-pp39-pypy39_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5f23ed1a1050d55b8512cf698b8d12800d711bcc3bea1b02ee8be785703a7386"},
+    {file = "numpy_minmax-0.3.1-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:1388b2446596348df3b724f768a8e820c61a13e45e3b093fa08ae340372b4e3b"},
+    {file = "numpy_minmax-0.3.1.tar.gz", hash = "sha256:3af3370161255298d8c5bc0b0f1d46bb09480ed7cd65f57037ebb49d2d322f31"},
+]
+
+[package.dependencies]
+cffi = ">=1.0.0"
+numpy = ">=1.21,<2"
+
+[package.extras]
+test = ["pytest"]
+
+[[package]]
+name = "numpy-rms"
+version = "0.4.2"
+description = "A fast python library for calculating the RMS of a NumPy array"
+optional = true
+python-versions = "*"
+files = [
+    {file = "numpy_rms-0.4.2-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:0f872b70578b8db26255d2334391bb60ff30139a8013392531da17713e9962cf"},
+    {file = "numpy_rms-0.4.2-cp310-cp310-macosx_11_0_arm64.whl", hash = "sha256:6b836d6c7a5bc11e6373abfc74f4d77ad1f1b4260c136e5c067357fe50a373d2"},
+    {file = "numpy_rms-0.4.2-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1733bac17dc77e3d3a535e4be9175d6360c50325196a851049a97e23c982f09e"},
+    {file = "numpy_rms-0.4.2-cp310-cp310-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:7f9221e98c503a291a65ee4afff119c2e96432ac373b250d17c001c230cf9a86"},
+    {file = "numpy_rms-0.4.2-cp310-cp310-musllinux_1_2_aarch64.whl", hash = "sha256:5a794f37c006e3a48e5d0702d379154618a9ff8a3f0a6cab92ac8453e4e0553a"},
+    {file = "numpy_rms-0.4.2-cp310-cp310-musllinux_1_2_x86_64.whl", hash = "sha256:67d3c682574991f727b5f0838530c290224a825aab17df85a2cb50de2aea5270"},
+    {file = "numpy_rms-0.4.2-cp310-cp310-win_amd64.whl", hash = "sha256:2e4d813f896f603737fa7aaab39a7a47c15c1848819dbe515fe4864bb78041d6"},
+    {file = "numpy_rms-0.4.2-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:cdd435a00597c849e213c615fb67f2be4bb85c1283ad37ad6bf7ca00bb44fd1f"},
+    {file = "numpy_rms-0.4.2-cp311-cp311-macosx_11_0_arm64.whl", hash = "sha256:136f233cacc9c3b7534a0877ad0c54174fee59c7ee6b59ebcd64bf814abbcc25"},
+    {file = "numpy_rms-0.4.2-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:1be36a85afe2d8201f8d032a8f825c9c54d9f96fd1f2dd85c34252dee5319533"},
+    {file = "numpy_rms-0.4.2-cp311-cp311-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a67ddc18c2a23972da7b6de38cfcea30b54f3b9cefd2dba00f7a198509b3c909"},
+    {file = "numpy_rms-0.4.2-cp311-cp311-musllinux_1_2_aarch64.whl", hash = "sha256:a2976156bb4356284e9367ff4f48ac25a0c512e5e481b359ce1f6dde6019c178"},
+    {file = "numpy_rms-0.4.2-cp311-cp311-musllinux_1_2_x86_64.whl", hash = "sha256:15fd446e5b10447d6e97628f0c17cde7a3e7cd5f3b4f246072fb5f4cfd28642c"},
+    {file = "numpy_rms-0.4.2-cp311-cp311-win_amd64.whl", hash = "sha256:2a22ec807e44a32cfea592a5e10bfa212b2d6d668e257c3880daa0c9fd066f7f"},
+    {file = "numpy_rms-0.4.2-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:2dcaf1f257cea1b3fb28d58ad351de2184a5f23ff41234f262a237a000b8ce55"},
+    {file = "numpy_rms-0.4.2-cp312-cp312-macosx_11_0_arm64.whl", hash = "sha256:e4d2636920e2bd1a221da7385d5da8000b9fd7393a1de091fbe3586ad31e7853"},
+    {file = "numpy_rms-0.4.2-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:885fde34172eb15fdc1aa804629b8cdeeb01e21fcd5b1c2a6d8a6516fc07f8dd"},
+    {file = "numpy_rms-0.4.2-cp312-cp312-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:b4a20f59a278eef196267858411fbd283e98373d2c6f989b02bcc33d785ac675"},
+    {file = "numpy_rms-0.4.2-cp312-cp312-musllinux_1_2_aarch64.whl", hash = "sha256:c9a5163ac0effda16fda77aff04eeab65ebeaef4afc2e3fe08cd19cfef84ced7"},
+    {file = "numpy_rms-0.4.2-cp312-cp312-musllinux_1_2_x86_64.whl", hash = "sha256:f9cabb0bff8046b6343c0d10b94759b00a0fd64dc13f2b238798287a352ff170"},
+    {file = "numpy_rms-0.4.2-cp312-cp312-win_amd64.whl", hash = "sha256:ff66710c0214cf943aaa8303565cb05356364703495c4ba809c6744b07df29ce"},
+    {file = "numpy_rms-0.4.2-cp38-cp38-macosx_10_9_x86_64.whl", hash = "sha256:5eb62c650861343641362b192df384716c8bac0c0ab63e9626a38e7e4e8f90e4"},
+    {file = "numpy_rms-0.4.2-cp38-cp38-macosx_11_0_arm64.whl", hash = "sha256:10021133c6ef2bdd07f1978c263ee186f5e9d970bded77fe7d93c8b13322dd34"},
+    {file = "numpy_rms-0.4.2-cp38-cp38-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:90dbd92c987fdd28536ef26128cd075d774a04fa5cfdf68f415bf0cacb6c0fd4"},
+    {file = "numpy_rms-0.4.2-cp38-cp38-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:793744df9d60daa7d58b3c7b62136bef127b49a8da5f71429ab65164082e2682"},
+    {file = "numpy_rms-0.4.2-cp38-cp38-musllinux_1_2_aarch64.whl", hash = "sha256:952ae4c9895745457f0611742caaba318066498e365a2f52d415928c664b72ab"},
+    {file = "numpy_rms-0.4.2-cp38-cp38-musllinux_1_2_x86_64.whl", hash = "sha256:d01e1021e79affc2cf0fb1439247250728c40e354bc0b68357841f6a5fa9a84c"},
+    {file = "numpy_rms-0.4.2-cp38-cp38-win_amd64.whl", hash = "sha256:53ac4b32a819c06ab005213b358f74866dec40da30404be00250a661ed242657"},
+    {file = "numpy_rms-0.4.2-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:660a8c46fd226140ac447ccb480c66b8b8ad207326a03db77063cfa645976b40"},
+    {file = "numpy_rms-0.4.2-cp39-cp39-macosx_11_0_arm64.whl", hash = "sha256:b609c9f6211a2667f336eaca717371f305cd142505bc737bef66f3314f923c50"},
+    {file = "numpy_rms-0.4.2-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9bee29a0f5fff0d5b5a94d001a64163a4114dd4181721b53f46592aa19726422"},
+    {file = "numpy_rms-0.4.2-cp39-cp39-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:db118e117ff51c3467aba7f4d12c87f129f65b5d2216f9640621838711fe72dd"},
+    {file = "numpy_rms-0.4.2-cp39-cp39-musllinux_1_2_aarch64.whl", hash = "sha256:18000baa61aec01f9930a993cc8893c6dca0b0dcfd198e6bb180a898a0ac7264"},
+    {file = "numpy_rms-0.4.2-cp39-cp39-musllinux_1_2_x86_64.whl", hash = "sha256:a0f97949cf9198fcbe849c0cf90a8ebaf5192916b84a39b90ec26564d889bab5"},
+    {file = "numpy_rms-0.4.2-cp39-cp39-win_amd64.whl", hash = "sha256:6308b0f00025ebeea63c1876a0815e026afb09eb47a8f109cbd2fc71c8abb501"},
+    {file = "numpy_rms-0.4.2-pp38-pypy38_pp73-macosx_10_9_x86_64.whl", hash = "sha256:ada1351d0a4475338ea77463e85a8af129fa1096020ac2a7bfc3bc6c95b1196d"},
+    {file = "numpy_rms-0.4.2-pp38-pypy38_pp73-macosx_11_0_arm64.whl", hash = "sha256:bc1996b8c04a000c7678775d28ff2bf9a064eef8deadd47d63d4a322592bb873"},
+    {file = "numpy_rms-0.4.2-pp38-pypy38_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:fe67f568583708418ee54f27fb10029ccfad71048f6d6bd5a3f78c35330d0db2"},
+    {file = "numpy_rms-0.4.2-pp38-pypy38_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:913d6336759d1255b275b04724aba20a6352ff971863d1e3dfce41681e7046ad"},
+    {file = "numpy_rms-0.4.2-pp38-pypy38_pp73-win_amd64.whl", hash = "sha256:c3e77e1a9fe2ff13318679e73ed3cfdc2e857308bb6eb2e2facde099556b9ee1"},
+    {file = "numpy_rms-0.4.2-pp39-pypy39_pp73-macosx_10_15_x86_64.whl", hash = "sha256:405e9591aeec05fe5ba5c1011e2d21b6b2aefc3043917f9ad57bc0b0a799f3a9"},
+    {file = "numpy_rms-0.4.2-pp39-pypy39_pp73-macosx_11_0_arm64.whl", hash = "sha256:b1e9ed9d77fe5e5e253e3eef0d3c8e7ee0ca47ddb7a178a2e12f863979747be2"},
+    {file = "numpy_rms-0.4.2-pp39-pypy39_pp73-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:0e6fbb544f5d75552b35549047b339adc3d34e0da49deb8ba5201b732c8ee032"},
+    {file = "numpy_rms-0.4.2-pp39-pypy39_pp73-manylinux_2_5_x86_64.manylinux1_x86_64.manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:1c81c5f194f4e879e70b6dce8e4ac8afb654fffc89c1a1e26695cc6bf643725c"},
+    {file = "numpy_rms-0.4.2-pp39-pypy39_pp73-win_amd64.whl", hash = "sha256:7bc7fe2df93cdf5d9b4478110320d14dadd8587c5846fcab006f370c37c3bcae"},
+    {file = "numpy_rms-0.4.2.tar.gz", hash = "sha256:cd1e82fb85afe24e963ec0f3465b90308b870b2395ec5144983d9b6c3979bff7"},
+]
+
+[package.dependencies]
+cffi = ">=1.0.0"
+numpy = ">=1.21,<2"
+
+[[package]]
 name = "nvidia-cublas-cu12"
 version = "12.1.3.1"
 description = "CUBLAS native runtime libraries"
@@ -3798,45 +3934,45 @@ tests = ["black (>=24.3.0)", "matplotlib (>=3.3.4)", "mypy (>=1.9)", "numpydoc (
 
 [[package]]
 name = "scipy"
-version = "1.13.1"
+version = "1.12.0"
 description = "Fundamental algorithms for scientific computing in Python"
 optional = false
 python-versions = ">=3.9"
 files = [
-    {file = "scipy-1.13.1-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:20335853b85e9a49ff7572ab453794298bcf0354d8068c5f6775a0eabf350aca"},
-    {file = "scipy-1.13.1-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:d605e9c23906d1994f55ace80e0125c587f96c020037ea6aa98d01b4bd2e222f"},
-    {file = "scipy-1.13.1-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:cfa31f1def5c819b19ecc3a8b52d28ffdcc7ed52bb20c9a7589669dd3c250989"},
-    {file = "scipy-1.13.1-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:f26264b282b9da0952a024ae34710c2aff7d27480ee91a2e82b7b7073c24722f"},
-    {file = "scipy-1.13.1-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:eccfa1906eacc02de42d70ef4aecea45415f5be17e72b61bafcfd329bdc52e94"},
-    {file = "scipy-1.13.1-cp310-cp310-win_amd64.whl", hash = "sha256:2831f0dc9c5ea9edd6e51e6e769b655f08ec6db6e2e10f86ef39bd32eb11da54"},
-    {file = "scipy-1.13.1-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:27e52b09c0d3a1d5b63e1105f24177e544a222b43611aaf5bc44d4a0979e32f9"},
-    {file = "scipy-1.13.1-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:54f430b00f0133e2224c3ba42b805bfd0086fe488835effa33fa291561932326"},
-    {file = "scipy-1.13.1-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e89369d27f9e7b0884ae559a3a956e77c02114cc60a6058b4e5011572eea9299"},
-    {file = "scipy-1.13.1-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a78b4b3345f1b6f68a763c6e25c0c9a23a9fd0f39f5f3d200efe8feda560a5fa"},
-    {file = "scipy-1.13.1-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:45484bee6d65633752c490404513b9ef02475b4284c4cfab0ef946def50b3f59"},
-    {file = "scipy-1.13.1-cp311-cp311-win_amd64.whl", hash = "sha256:5713f62f781eebd8d597eb3f88b8bf9274e79eeabf63afb4a737abc6c84ad37b"},
-    {file = "scipy-1.13.1-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:5d72782f39716b2b3509cd7c33cdc08c96f2f4d2b06d51e52fb45a19ca0c86a1"},
-    {file = "scipy-1.13.1-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:017367484ce5498445aade74b1d5ab377acdc65e27095155e448c88497755a5d"},
-    {file = "scipy-1.13.1-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:949ae67db5fa78a86e8fa644b9a6b07252f449dcf74247108c50e1d20d2b4627"},
-    {file = "scipy-1.13.1-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:de3ade0e53bc1f21358aa74ff4830235d716211d7d077e340c7349bc3542e884"},
-    {file = "scipy-1.13.1-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:2ac65fb503dad64218c228e2dc2d0a0193f7904747db43014645ae139c8fad16"},
-    {file = "scipy-1.13.1-cp312-cp312-win_amd64.whl", hash = "sha256:cdd7dacfb95fea358916410ec61bbc20440f7860333aee6d882bb8046264e949"},
-    {file = "scipy-1.13.1-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:436bbb42a94a8aeef855d755ce5a465479c721e9d684de76bf61a62e7c2b81d5"},
-    {file = "scipy-1.13.1-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:8335549ebbca860c52bf3d02f80784e91a004b71b059e3eea9678ba994796a24"},
-    {file = "scipy-1.13.1-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:d533654b7d221a6a97304ab63c41c96473ff04459e404b83275b60aa8f4b7004"},
-    {file = "scipy-1.13.1-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:637e98dcf185ba7f8e663e122ebf908c4702420477ae52a04f9908707456ba4d"},
-    {file = "scipy-1.13.1-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:a014c2b3697bde71724244f63de2476925596c24285c7a637364761f8710891c"},
-    {file = "scipy-1.13.1-cp39-cp39-win_amd64.whl", hash = "sha256:392e4ec766654852c25ebad4f64e4e584cf19820b980bc04960bca0b0cd6eaa2"},
-    {file = "scipy-1.13.1.tar.gz", hash = "sha256:095a87a0312b08dfd6a6155cbbd310a8c51800fc931b8c0b84003014b874ed3c"},
+    {file = "scipy-1.12.0-cp310-cp310-macosx_10_9_x86_64.whl", hash = "sha256:78e4402e140879387187f7f25d91cc592b3501a2e51dfb320f48dfb73565f10b"},
+    {file = "scipy-1.12.0-cp310-cp310-macosx_12_0_arm64.whl", hash = "sha256:f5f00ebaf8de24d14b8449981a2842d404152774c1a1d880c901bf454cb8e2a1"},
+    {file = "scipy-1.12.0-cp310-cp310-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:e53958531a7c695ff66c2e7bb7b79560ffdc562e2051644c5576c39ff8efb563"},
+    {file = "scipy-1.12.0-cp310-cp310-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:5e32847e08da8d895ce09d108a494d9eb78974cf6de23063f93306a3e419960c"},
+    {file = "scipy-1.12.0-cp310-cp310-musllinux_1_1_x86_64.whl", hash = "sha256:4c1020cad92772bf44b8e4cdabc1df5d87376cb219742549ef69fc9fd86282dd"},
+    {file = "scipy-1.12.0-cp310-cp310-win_amd64.whl", hash = "sha256:75ea2a144096b5e39402e2ff53a36fecfd3b960d786b7efd3c180e29c39e53f2"},
+    {file = "scipy-1.12.0-cp311-cp311-macosx_10_9_x86_64.whl", hash = "sha256:408c68423f9de16cb9e602528be4ce0d6312b05001f3de61fe9ec8b1263cad08"},
+    {file = "scipy-1.12.0-cp311-cp311-macosx_12_0_arm64.whl", hash = "sha256:5adfad5dbf0163397beb4aca679187d24aec085343755fcdbdeb32b3679f254c"},
+    {file = "scipy-1.12.0-cp311-cp311-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:c3003652496f6e7c387b1cf63f4bb720951cfa18907e998ea551e6de51a04467"},
+    {file = "scipy-1.12.0-cp311-cp311-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:8b8066bce124ee5531d12a74b617d9ac0ea59245246410e19bca549656d9a40a"},
+    {file = "scipy-1.12.0-cp311-cp311-musllinux_1_1_x86_64.whl", hash = "sha256:8bee4993817e204d761dba10dbab0774ba5a8612e57e81319ea04d84945375ba"},
+    {file = "scipy-1.12.0-cp311-cp311-win_amd64.whl", hash = "sha256:a24024d45ce9a675c1fb8494e8e5244efea1c7a09c60beb1eeb80373d0fecc70"},
+    {file = "scipy-1.12.0-cp312-cp312-macosx_10_9_x86_64.whl", hash = "sha256:e7e76cc48638228212c747ada851ef355c2bb5e7f939e10952bc504c11f4e372"},
+    {file = "scipy-1.12.0-cp312-cp312-macosx_12_0_arm64.whl", hash = "sha256:f7ce148dffcd64ade37b2df9315541f9adad6efcaa86866ee7dd5db0c8f041c3"},
+    {file = "scipy-1.12.0-cp312-cp312-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:9c39f92041f490422924dfdb782527a4abddf4707616e07b021de33467f917bc"},
+    {file = "scipy-1.12.0-cp312-cp312-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:a7ebda398f86e56178c2fa94cad15bf457a218a54a35c2a7b4490b9f9cb2676c"},
+    {file = "scipy-1.12.0-cp312-cp312-musllinux_1_1_x86_64.whl", hash = "sha256:95e5c750d55cf518c398a8240571b0e0782c2d5a703250872f36eaf737751338"},
+    {file = "scipy-1.12.0-cp312-cp312-win_amd64.whl", hash = "sha256:e646d8571804a304e1da01040d21577685ce8e2db08ac58e543eaca063453e1c"},
+    {file = "scipy-1.12.0-cp39-cp39-macosx_10_9_x86_64.whl", hash = "sha256:913d6e7956c3a671de3b05ccb66b11bc293f56bfdef040583a7221d9e22a2e35"},
+    {file = "scipy-1.12.0-cp39-cp39-macosx_12_0_arm64.whl", hash = "sha256:bba1b0c7256ad75401c73e4b3cf09d1f176e9bd4248f0d3112170fb2ec4db067"},
+    {file = "scipy-1.12.0-cp39-cp39-manylinux_2_17_aarch64.manylinux2014_aarch64.whl", hash = "sha256:730badef9b827b368f351eacae2e82da414e13cf8bd5051b4bdfd720271a5371"},
+    {file = "scipy-1.12.0-cp39-cp39-manylinux_2_17_x86_64.manylinux2014_x86_64.whl", hash = "sha256:6546dc2c11a9df6926afcbdd8a3edec28566e4e785b915e849348c6dd9f3f490"},
+    {file = "scipy-1.12.0-cp39-cp39-musllinux_1_1_x86_64.whl", hash = "sha256:196ebad3a4882081f62a5bf4aeb7326aa34b110e533aab23e4374fcccb0890dc"},
+    {file = "scipy-1.12.0-cp39-cp39-win_amd64.whl", hash = "sha256:b360f1b6b2f742781299514e99ff560d1fe9bd1bff2712894b52abe528d1fd1e"},
+    {file = "scipy-1.12.0.tar.gz", hash = "sha256:4bf5abab8a36d20193c698b0f1fc282c1d083c94723902c447e5d2f1780936a3"},
 ]
 
 [package.dependencies]
-numpy = ">=1.22.4,<2.3"
+numpy = ">=1.22.4,<1.29.0"
 
 [package.extras]
-dev = ["cython-lint (>=0.12.2)", "doit (>=0.36.0)", "mypy", "pycodestyle", "pydevtool", "rich-click", "ruff", "types-psutil", "typing_extensions"]
-doc = ["jupyterlite-pyodide-kernel", "jupyterlite-sphinx (>=0.12.0)", "jupytext", "matplotlib (>=3.5)", "myst-nb", "numpydoc", "pooch", "pydata-sphinx-theme (>=0.15.2)", "sphinx (>=5.0.0)", "sphinx-design (>=0.4.0)"]
-test = ["array-api-strict", "asv", "gmpy2", "hypothesis (>=6.30)", "mpmath", "pooch", "pytest", "pytest-cov", "pytest-timeout", "pytest-xdist", "scikit-umfpack", "threadpoolctl"]
+dev = ["click", "cython-lint (>=0.12.2)", "doit (>=0.36.0)", "mypy", "pycodestyle", "pydevtool", "rich-click", "ruff", "types-psutil", "typing_extensions"]
+doc = ["jupytext", "matplotlib (>2)", "myst-nb", "numpydoc", "pooch", "pydata-sphinx-theme (==0.9.0)", "sphinx (!=4.1.0)", "sphinx-design (>=0.2.0)"]
+test = ["asv", "gmpy2", "hypothesis", "mpmath", "pooch", "pytest", "pytest-cov", "pytest-timeout", "pytest-xdist", "scikit-umfpack", "threadpoolctl"]
 
 [[package]]
 name = "seaborn"
@@ -5157,14 +5293,15 @@ type = ["pytest-mypy"]
 
 [extras]
 albumentations = ["albumentations"]
-all = ["albumentations", "latex", "mlflow", "opensmile", "tensorboard", "torch-audiomentations"]
-audiomentations = ["torch-audiomentations"]
+all = ["albumentations", "audiomentations", "latex", "mlflow", "opensmile", "tensorboard", "torch-audiomentations"]
+audiomentations = ["audiomentations"]
 latex = ["latex"]
 mlflow = ["mlflow"]
 opensmile = ["opensmile"]
 tensorboard = ["tensorboard"]
+torch-audiomentations = ["torch-audiomentations"]
 
 [metadata]
 lock-version = "2.0"
 python-versions = "^3.9"
-content-hash = "efb50b1c1ad27ffee6b0d23c7d7595da79f3c2966ad712ec9cf5aab1d1226b48"
+content-hash = "e285d6dd195ba5d6481bcaa1c1fb23835ecdcbf28b928b34007c8d8b05e07bb2"

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -69,7 +69,7 @@ transformers = "^4.34.0"
 
 [tool.poetry.extras]
 albumentations = ["albumentations"]
-audiomentations = ["torch-audiomentations"]
+torch-audiomentations = ["torch-audiomentations"]
 latex = ["latex"]
 mlflow = ["mlflow"]
 opensmile = ["opensmile"]

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -36,6 +36,7 @@ documentation = "https://autrainer.github.io/autrainer/"
 python = "^3.9"
 albumentations = { version = "^1.4.10", optional = true }
 audiofile = "^1.3.0"
+audiomentations = { version = "^0.37.0", optional = true, python = ">=3.9,<=3.12" }
 audmetric = "^1.2.0"
 audobject = "^0.7.11"
 audtorch = "^0.6.4"
@@ -69,18 +70,20 @@ transformers = "^4.34.0"
 
 [tool.poetry.extras]
 albumentations = ["albumentations"]
-torch-audiomentations = ["torch-audiomentations"]
+audiomentations = ["audiomentations"]
 latex = ["latex"]
 mlflow = ["mlflow"]
 opensmile = ["opensmile"]
 tensorboard = ["tensorboard"]
+torch-audiomentations = ["torch-audiomentations"]
 all = [
     "albumentations",
-    "torch-audiomentations",
+    "audiomentations",
     "latex",
     "mlflow",
     "opensmile",
     "tensorboard",
+    "torch-audiomentations",
 ]
 
 [tool.poetry.group.dev.dependencies]

--- a/tests/test_augmentations.py
+++ b/tests/test_augmentations.py
@@ -10,7 +10,6 @@ import torch
 from autrainer.augmentations import (
     AbstractAugmentation,
     AlbumentationsAugmentation,
-    AudiomentationsAugmentation,
     AugmentationManager,
     Choice,
     CutMix,
@@ -24,6 +23,7 @@ from autrainer.augmentations import (
     TimeShift,
     TimeWarp,
     TorchaudioAugmentation,
+    TorchAudiomentationsAugmentation,
     TorchvisionAugmentation,
 )
 from autrainer.augmentations.image_augmentations import BaseMixUpCutMix
@@ -37,12 +37,6 @@ AUGMENTATION_FIXTURES = [
         {"name": "Posterize"},
         (3, 32, 32),
         (3, 32, 32),
-    ),
-    (
-        AudiomentationsAugmentation,
-        {"name": "AddColoredNoise", "sample_rate": 16000, "min_f_decay": -1},
-        (1, 16000),
-        (1, 16000),
     ),
     (
         Choice,
@@ -80,6 +74,12 @@ AUGMENTATION_FIXTURES = [
         {"name": "FrequencyMasking", "freq_mask_param": 10},
         (1, 101, 64),
         (1, 101, 64),
+    ),
+    (
+        TorchAudiomentationsAugmentation,
+        {"name": "AddColoredNoise", "sample_rate": 16000, "min_f_decay": -1},
+        (1, 16000),
+        (1, 16000),
     ),
     (
         TorchvisionAugmentation,

--- a/tests/test_augmentations.py
+++ b/tests/test_augmentations.py
@@ -10,6 +10,7 @@ import torch
 from autrainer.augmentations import (
     AbstractAugmentation,
     AlbumentationsAugmentation,
+    AudiomentationsAugmentation,
     AugmentationManager,
     Choice,
     CutMix,
@@ -37,6 +38,12 @@ AUGMENTATION_FIXTURES = [
         {"name": "Posterize"},
         (3, 32, 32),
         (3, 32, 32),
+    ),
+    (
+        AudiomentationsAugmentation,
+        {"name": "PitchShift", "sample_rate": 16000},
+        (1, 16000),
+        (1, 16000),
     ),
     (
         Choice,


### PR DESCRIPTION
Closes #10 by adding a `AudiomentationsAugmentation` wrapper around [audiomentations](https://github.com/iver56/audiomentations) and thus moving the [torch-audiomentations](https://github.com/asteroid-team/torch-audiomentations) wrapper to `TorchAudiomentationsAugmentation`.

This gives the user more freedom on choosing audio augmentations, since `torch-audiomentations` does  not (yet) offer full feature parity.
However using `audiomentations` comes at the drawback that all augmentations need to be converted to numpy arrays and back to tensors in the pipeline.
Also added this info to the docstrings of the numpy-based augmentation wrappers.