### PR TITLE
Modularize CUDA-enabled Device Selection

### DIFF
--- a/autrainer-configurations/_autrainer_.yaml
+++ b/autrainer-configurations/_autrainer_.yaml
@@ -12,6 +12,7 @@ training_type: epoch
 eval_frequency: 1
 save_frequency: ${eval_frequency}
 inference_batch_size: ${batch_size}
+device: cuda:0
 
 progress_bar: true
 continue_training: true

--- a/autrainer/core/utils/__init__.py
+++ b/autrainer/core/utils/__init__.py
@@ -1,5 +1,5 @@
 from .bookkeeping import Bookkeeping
-from .hardware_info import get_hardware_info, save_hardware_info
+from .hardware import get_hardware_info, save_hardware_info, set_device
 from .set_seed import set_seed
 from .silence import silence
 from .timer import Timer
@@ -7,9 +7,10 @@ from .timer import Timer
 
 __all__ = [
     "Bookkeeping",
-    "Timer",
     "get_hardware_info",
     "save_hardware_info",
+    "set_device",
     "set_seed",
     "silence",
+    "Timer",
 ]

--- a/autrainer/serving/serving.py
+++ b/autrainer/serving/serving.py
@@ -11,6 +11,7 @@ import torch
 import yaml
 
 import autrainer
+from autrainer.core.utils import set_device
 from autrainer.datasets.utils import (
     AbstractFileHandler,
     AbstractTargetTransform,
@@ -53,7 +54,7 @@ class Inference:
         """
         self._model_path = model_path
         self._checkpoint = checkpoint
-        self._device = torch.device(device)
+        self._device = set_device(device)
         self._preprocess_cfg = preprocess_cfg
         self._window_length = window_length
         self._stride_length = stride_length

--- a/autrainer/training/training.py
+++ b/autrainer/training/training.py
@@ -15,6 +15,7 @@ from autrainer.core.utils import (
     Bookkeeping,
     Timer,
     save_hardware_info,
+    set_device,
     set_seed,
 )
 from autrainer.datasets import AbstractDataset
@@ -54,7 +55,8 @@ class ModularTaskTrainer:
         else:
             training_seed = dataset_seed = self.cfg.seed
         set_seed(training_seed)
-        save_hardware_info(output_directory)
+        self.DEVICE = set_device(self.cfg.device)
+        save_hardware_info(output_directory, device=self.DEVICE)
         self.output_directory = Path(output_directory)
         self.initial_iteration = 1
 
@@ -110,9 +112,6 @@ class ModularTaskTrainer:
         self.task = self.data.task
 
         # ? Misc Training Parameters
-        self.DEVICE = torch.device(
-            "cuda:0" if torch.cuda.is_available() else "cpu"
-        )
         self.disable_progress_bar = not self.cfg.get("progress_bar", False)
 
         self.criterion = autrainer.instantiate_shorthand(

--- a/docs/source/usage/hydra_configurations.rst
+++ b/docs/source/usage/hydra_configurations.rst
@@ -247,7 +247,7 @@ The :file:`_autrainer_.yaml` file contains further default configurations to sim
 which includes:
 
 * The :ref:`defaults list <defaults_list>` and :ref:`optional defaults list <optional_defaults_list>`.
-* Global default parameters for :ref:`training <training>`.
+* Global default parameters for :ref:`training <training>`, such as the evaluation frequency, save frequency, inference batch size, CUDA-enabled device, etc.
 * Hydra configurations for always starting a `Hydra multirun <https://hydra.cc/docs/1.0/tutorials/basic/running_your_app/multi-run/>`_ (grid search)
   and setting the output directory and experiment name according to the current configuration.
 


### PR DESCRIPTION
Closes #9 and allow for the selection of different devices for training (defaults to `device: cuda:0`).
If the specified device is not available (or valid), automatically falls back to using the CPU and logs out a warning.

This also applies to inference, where this check was previously missed and could fail if a nonexistent device was selected.

Also: During tracking of the outputs, we need to recompute the non-reduced loss as manually summing up the losses in the main training loop leads to a different loss for some reason. This was previously also done on GPU (if available), but is now moved to the CPU.