### PR TITLE
Save Preprocessing Pipeline for Inference

### DIFF
--- a/autrainer/core/scripts/inference_script.py
+++ b/autrainer/core/scripts/inference_script.py
@@ -130,12 +130,14 @@ class InferenceScript(AbstractScript):
             type=str,
             metavar="P",
             required=False,
-            default=None,
+            default="default",
             help=(
                 "Preprocessing configuration to apply to input. Can be a path "
                 "to a YAML file or the name of the preprocessing configuration "
                 "in the local or autrainer 'conf/preprocessing' directory. "
-                "If None, no preprocessing will be applied. Defaults to None."
+                "If 'default', the default preprocessing configuration used "
+                "during training will be applied. If 'None', no preprocessing "
+                "will be applied. Defaults to 'default'."
             ),
         )
         self.parser.add_argument(
@@ -195,7 +197,7 @@ class InferenceScript(AbstractScript):
         self._assert_valid_input(args)
         self._assert_valid_device(args)
         self._assert_valid_checkpoint(args)
-        self._assert_preprocess_cfg_exists(args)
+        self._assert_and_set_preprocess_path(args)
         self._inference(args)
 
     def _assert_model_exists(self, args: InferenceArgs) -> str:
@@ -266,8 +268,12 @@ class InferenceScript(AbstractScript):
             code=1,
         )
 
-    def _assert_preprocess_cfg_exists(self, args: InferenceArgs) -> None:
-        if args.preprocess_cfg is None:
+    def _assert_and_set_preprocess_path(self, args: InferenceArgs) -> None:
+        if args.preprocess_cfg == "default":
+            return
+
+        if args.preprocess_cfg == "None" or args.preprocess_cfg is None:
+            args.preprocess_cfg = None
             return
 
         if not args.preprocess_cfg.endswith(".yaml"):
@@ -347,7 +353,7 @@ def inference(
     extension: str = "wav",
     recursive: bool = False,
     embeddings: bool = False,
-    preprocess_cfg: Optional[str] = None,
+    preprocess_cfg: Optional[str] = "default",
     window_length: Optional[float] = None,
     stride_length: Optional[float] = None,
     min_length: Optional[float] = None,
@@ -380,8 +386,9 @@ def inference(
         preprocess_cfg: Preprocessing configuration to apply to input. Can be
             a path to a YAML file or the name of the preprocessing
             configuration in the local or autrainer 'conf/preprocessing'
-            directory. If None, no preprocessing will be applied.
-            Defaults to None.
+            directory. If "default", the default preprocessing configuration
+            used during training will be applied. If None, no preprocessing
+            will be applied. Defaults to "default".
         window_length: Window length for sliding window inference in seconds.
             If None, the entire input will be processed at once.
             Defaults to None.

--- a/autrainer/serving/model_paths.py
+++ b/autrainer/serving/model_paths.py
@@ -10,6 +10,8 @@ MODEL_FILES = [
     "file_handler.yaml",
     "target_transform.yaml",
     "inference_transform.yaml",
+    "preprocess_file_handler.yaml",
+    "preprocess_pipeline.yaml",
 ]
 SAVE_FILES = tuple(["model.pt"] + MODEL_FILES)
 

--- a/autrainer/serving/serving.py
+++ b/autrainer/serving/serving.py
@@ -26,7 +26,7 @@ class Inference:
         model_path: str,
         checkpoint: str = "_best",
         device: str = "cpu",
-        preprocess_cfg: Optional[str] = None,
+        preprocess_cfg: Optional[str] = "default",
         window_length: Optional[float] = None,
         stride_length: Optional[float] = None,
         min_length: Optional[float] = None,
@@ -41,7 +41,10 @@ class Inference:
             checkpoint: Checkpoint directory containing a model.pt file.
                 Defaults to "_best".
             device: Device to run inference on. Defaults to "cpu".
-            preprocess_cfg: Preprocessing configuration file. Defaults to None.
+            preprocess_cfg: Preprocessing configuration file. If "default",
+                the default preprocessing pipeline used during training is
+                applied. If None, no preprocessing is applied. Defaults to
+                "default".
             window_length: Window length in seconds for sliding window
                 inference. Defaults to None.
             stride_length: Stride length in seconds for sliding window
@@ -86,7 +89,14 @@ class Inference:
         )
 
         self.preprocess_pipeline = SmartCompose([])
-        if self._preprocess_cfg is not None:
+        if self._preprocess_cfg == "default":
+            self.file_handler: AbstractFileHandler = audobject.from_yaml(
+                os.path.join(self._model_path, "preprocess_file_handler.yaml")
+            )
+            self.preprocess_pipeline: SmartCompose = audobject.from_yaml(
+                os.path.join(self._model_path, "preprocess_pipeline.yaml")
+            )
+        elif self._preprocess_cfg is not None:
             preprocess_cfg = OmegaConf.to_container(
                 OmegaConf.load(self._preprocess_cfg)
             )

--- a/tests/test_cli_wrapper.py
+++ b/tests/test_cli_wrapper.py
@@ -278,6 +278,8 @@ class TestCLIInference(BaseIndividualTempDir):
             "file_handler.yaml",
             "target_transform.yaml",
             "inference_transform.yaml",
+            "preprocess_file_handler.yaml",
+            "preprocess_pipeline.yaml",
         ]:
             OmegaConf.save({}, f"model/{file}")
 


### PR DESCRIPTION
Closes #20 and additionally exports a `preprocess_file_handler.yaml` and `preprocess_pipeline.yaml` to be used during inference based on the `features_subdir` of the dataset.
If no preprocessing pipeline is used, `preprocess_file_handler.yaml` is the same as `file_handler.yaml`.

During inference `-p` / `preprocess-cfg` is now set to `default`, automatically loading the preprocessing pipeline used during training. If spectrograms were used for training, the user can still pass audio during inference and it is automatically transformed to spectrograms.
However, this can still be deactivated by setting the preprocessing config to `None` to disable preprocessing or to any local / global preprocessing pipeline. This essentially covers the old implementation.

I currently just "re-export" the preprocessing pipeline as an audobject during training, so that inference does not rely on Hydra (we dont have a Hydra instance during inference). This could also be done during preprocessing, and during training just copy `preprocess_file_handler.yaml` and `preprocess_pipeline.yaml` from the respective `features_subdir` if it exists, otherwise export the default YAML files.
However, i thought that the current version had less hidden control flow.

Some time in the future we should think about improving the performance of the trainer init, as it gets more and more tasks now. Saving more audobjects definitely adds a couple seconds, but is maybe parallelizable.