### PR TITLE
Fix Multi-Label Classification Threshold

### DIFF
--- a/autrainer/datasets/utils/target_transforms.py
+++ b/autrainer/datasets/utils/target_transforms.py
@@ -197,7 +197,7 @@ class MultiLabelEncoder(AbstractTargetTransform):
         Returns:
             Binary tensor of encoded predictions.
         """
-        return (x > self.threshold).int().squeeze().tolist()
+        return (torch.sigmoid(x) > self.threshold).int().squeeze().tolist()
 
     def majority_vote(self, x: List[List[str]]) -> List[str]:
         """Get the majority vote from a list of lists of decoded target labels

--- a/tests/test_dataset_utils.py
+++ b/tests/test_dataset_utils.py
@@ -112,7 +112,7 @@ class TestMultiLabelEncoder:
 
     def test_predict_batch(self) -> None:
         encoder = MultiLabelEncoder(0.5, self.labels)
-        x = torch.Tensor([0.1, 0.9, 0.6])
+        x = torch.Tensor([-0.1, 0.9, 0.6])
         assert encoder.predict_batch(x) == [
             0,
             1,


### PR DESCRIPTION
Closes #18 and adds sigmoid activation to the model outputs for multi-label prediction.