### PR TITLE
Fix Inconsistent Scheduler Step Call Positions

### DIFF
--- a/autrainer-configurations/scheduler/StepLR.yaml
+++ b/autrainer-configurations/scheduler/StepLR.yaml
@@ -1,3 +1,5 @@
 id: StepLR
 _target_: torch.optim.lr_scheduler.StepLR
 step_size: 30
+
+step_frequency: evaluation

--- a/docs/source/examples/tutorials/LinearWarmUpLR.yaml
+++ b/docs/source/examples/tutorials/LinearWarmUpLR.yaml
@@ -2,3 +2,5 @@ id: LinearWarmUpLR
 _target_: linear_warm_up_lr.LinearWarmUpLR
 
 warmup_steps: 10
+
+step_frequency: evaluation

--- a/docs/source/modules/schedulers.rst
+++ b/docs/source/modules/schedulers.rst
@@ -6,6 +6,14 @@ Schedulers
 Schedulers are optional and by default not used.
 This is indicated by the absence of the :attr:`scheduler` attribute in the sweeper configuration (implicitly set to a :attr:`None` configuration file).
 
+In addition to the :attr:`id`, :attr:`_target_`, and scheduler-specific attributes, schedulers can have the following attributes:
+
+* :attr:`step_frequency` (str): The frequency at which the step function is called during training. Possible values are:
+  
+  * :attr:`batch`: The step function is called after every batch. Defaults to :attr:`batch` if not specified.
+  * :attr:`evaluation`: The step function is called after the number of iterations specified by the :attr:`eval_frequency`
+    of the :ref:`training configuration <training>`.
+
 To use a scheduler, specify it in the configuration file (:file:`conf/config.yaml`) for the sweeper.
 
 .. tip::


### PR DESCRIPTION
Closes #17 and adds a new `step_frequency` attribute to the scheduler configuration:
- `batch`: called after every batch (default).
- `evaluation`: called after `eval_frequency` iterations.

This way, regardless of the scheduler used, it can be called at the appropriate time.
More advanced schedulers can always be implemented via callbacks.