### PR TITLE
Fix Hugging Face Model Local Path Directory

### DIFF
--- a/autrainer/serving/model_paths.py
+++ b/autrainer/serving/model_paths.py
@@ -112,8 +112,7 @@ class HubModelPath(AbstractModelPath):
             or os.path.join(
                 torch.hub.get_dir(),
                 "autrainer",
-                repo_id.replace("/", "--"),
-                f"--{revision or 'main'}",
+                repo_id.replace("/", "--") + f"--{revision or 'main'}",
             )
         ).as_posix()
         self.files = [


### PR DESCRIPTION
As mentioned in #19 the local hugging face model path is constructed wrong. This fixes the naming and concatenates the revision instead of creating a sub directory.