### PR TITLE
Fix Audio File Handler Deserialization

### DIFF
--- a/autrainer/datasets/utils/file_handlers.py
+++ b/autrainer/datasets/utils/file_handlers.py
@@ -132,7 +132,11 @@ class NumpyFileHandler(AbstractFileHandler):
 
 
 class AudioFileHandler(AbstractFileHandler):
-    def __init__(self, target_sample_rate: Optional[int] = None, **kwargs):
+    def __init__(
+        self,
+        target_sample_rate: Optional[int] = None,
+        **kwargs,
+    ) -> None:
         """Audio file handler with optional resampling.
 
         Args:
@@ -143,6 +147,9 @@ class AudioFileHandler(AbstractFileHandler):
             **kwargs: Additional keyword arguments passed to
                 torchaudio.transforms.Resample.
         """
+        # ? audobject passes _object_root_ to the object, which is not a valid
+        # ? argument for the file handler.
+        kwargs.pop("_object_root_", None)
         self.target_sample_rate = target_sample_rate
         self.kwargs = kwargs
 


### PR DESCRIPTION
For inference, we deserialize our yaml files using `audobject.from_yaml()`.
Some of our classes have catch all `**kwargs` in their `__init__` functions, leading to the following try catch block to not throw a type error:
https://github.com/audeering/audobject/blob/2e9e40f5ed1b12b40174eb5984bc2bb0f6ed2dd3/audobject/core/api.py#L82-L96

This way, audobject cannot remove the `_object_root_` attribute created during loading the object, and we have to do it manually for now (only affects classes with `**kwargs` that are serialized with `audobject` for inference).
Maybe there is a better solution in the future.

