### PR TITLE
Fix Preprocessing CLI Defaults and Improve Efficiency

### DIFF
--- a/autrainer/core/scripts/preprocess_script.py
+++ b/autrainer/core/scripts/preprocess_script.py
@@ -45,10 +45,13 @@ class PreprocessScript(AbstractPreprocessScript):
             "-n",
             "--num-workers",
             type=int,
-            default=-1,
+            default=1,
             metavar="N",
             required=False,
-            help="Number of workers to use for preprocessing. Defaults to -1.",
+            help=(
+                "Number of workers (threads) to use for preprocessing. "
+                "Defaults to 1."
+            ),
         )
         self.parser.add_argument(
             "-p",
@@ -138,18 +141,14 @@ class PreprocessScript(AbstractPreprocessScript):
             return pd.concat(dfs, ignore_index=True)[column].unique().tolist()
 
         def _create_subdirs(path: str, files: List[str]) -> None:
-            for f in files:
-                os.makedirs(
-                    os.path.dirname(os.path.join(path, f)),
-                    exist_ok=True,
-                )
+            dirs = {os.path.dirname(os.path.join(path, f)) for f in files}
 
-        def _get_num_chunks() -> int:
-            if self.num_workers == -1:
-                return os.cpu_count() or 1
-            return self.num_workers
+            for d in dirs:
+                os.makedirs(d, exist_ok=True)
 
         def _split_chunks(files: List[str], chunks: int) -> List[List[str]]:
+            if chunks == 1:
+                return [files]
             avg = len(files) / chunks
             out = []
             last = 0
@@ -215,13 +214,14 @@ class PreprocessScript(AbstractPreprocessScript):
                 os.path.join(dataset["path"], dataset["features_subdir"]),
                 unique_files,
             )
-            num_chunks = _get_num_chunks()
-            chunks = _split_chunks(unique_files, num_chunks)
+            chunks = _split_chunks(unique_files, self.num_workers)
             lock = tqdm.get_lock()
             with tqdm(
-                total=len(unique_files), desc=name, disable=self.silent
+                total=len(unique_files),
+                desc=name,
+                disable=self.silent,
             ) as pbar:
-                with ThreadPoolExecutor(max_workers=num_chunks) as executor:
+                with ThreadPoolExecutor(self.num_workers) as executor:
                     futures = [
                         executor.submit(
                             _process_chunk,
@@ -240,7 +240,7 @@ class PreprocessScript(AbstractPreprocessScript):
 @catch_cli_errors
 def preprocess(
     override_kwargs: Optional[dict] = None,
-    num_workers: int = -1,
+    num_workers: int = 1,
     pbar_frequency: int = 100,
     silent: bool = False,
     cfg_launcher: bool = False,
@@ -252,8 +252,8 @@ def preprocess(
     Args:
         override_kwargs: Additional Hydra override arguments to pass to the
             train script.
-        num_workers: Number of workers to use for preprocessing.
-            Defaults to -1.
+        num_workers: Number of workers (threads) to use for preprocessing.
+            Defaults to 1.
         pbar_frequency: Frequency of progress bar updates. Defaults to 100.
         silent: Disable progress bar output. Defaults to False.
         cfg_launcher: Use the launcher specified in the configuration instead

--- a/autrainer/core/scripts/preprocess_script.py
+++ b/autrainer/core/scripts/preprocess_script.py
@@ -69,6 +69,8 @@ class PreprocessScript(AbstractPreprocessScript):
         )
 
     def main(self, args: PreprocessArgs) -> None:
+        self._assert_num_workers(args.num_workers)
+
         import hydra
 
         self.num_workers = args.num_workers
@@ -101,6 +103,12 @@ class PreprocessScript(AbstractPreprocessScript):
         main()
         self._preprocess_datasets()
         self._clean_up()
+
+    def _assert_num_workers(self, num_workers: int) -> None:
+        if num_workers < 1:
+            raise ValueError(
+                f"Number of workers '{num_workers}' must be >= 1."
+            )
 
     def _preprocess_datasets(self) -> None:
         from concurrent.futures import ThreadPoolExecutor

--- a/autrainer/core/scripts/preprocess_script.py
+++ b/autrainer/core/scripts/preprocess_script.py
@@ -190,6 +190,7 @@ class PreprocessScript(AbstractPreprocessScript):
                 data = file_handler.load(in_path)
                 data = pipeline(data, 0)
                 output_file_handler.save(out_path, data)
+                del data
                 file_count += 1
                 if file_count % self.pbar_frequency == 0:
                     with lock:


### PR DESCRIPTION
Closes #27 where a OOM error was encountered as too many threads were spawned due to the default being `num_workers = -1`.
It is definitely more safe to have users manually increase the number of threads they want to use, therefore:
- set `num_workers` to 1 by default and checking if they are greater or equal than one, clearly indicate workers == threads
- only perform necessary directory creation calls by filtering first
- improve memory efficiency by explicitly marking the processed data for deletion instead of waiting for the reference to be dropped in the next iteration