### PR TITLE
Improve Dataset Structure Explanation

### DIFF
--- a/docs/source/examples/tutorials/ESC50-32k.yaml
+++ b/docs/source/examples/tutorials/ESC50-32k.yaml
@@ -8,6 +8,10 @@ target_column: category
 file_type: npy
 file_handler: autrainer.datasets.utils.NumpyFileHandler
 
+train_folds: [1, 2, 3]
+dev_folds: [4]
+test_folds: [5]
+
 criterion: autrainer.criterions.BalancedCrossEntropyLoss
 metrics: 
   - autrainer.metrics.Accuracy

--- a/docs/source/examples/tutorials/esc_50.py
+++ b/docs/source/examples/tutorials/esc_50.py
@@ -1,5 +1,6 @@
 import os
 import shutil
+from typing import Any, Dict, List, Tuple
 
 import pandas as pd
 
@@ -11,6 +12,28 @@ FILES = {"ESC-50.zip": "https://github.com/karoldvl/ESC-50/archive/master.zip"}
 
 
 class ESC50(BaseClassificationDataset):
+    def __init__(
+        self,
+        train_folds: List[int],
+        dev_folds: List[int],
+        test_folds: List[int],
+        **kwargs: Dict[str, Any],  # kwargs only for simplicity in the tutorial
+    ) -> None:
+        self.train_folds = train_folds
+        self.dev_folds = dev_folds
+        self.test_folds = test_folds
+        super().__init__(**kwargs)
+
+    def load_dataframes(
+        self,
+    ) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+        meta = pd.read_csv(os.path.join(self.path, "esc50.csv"))
+        return (
+            meta[meta["fold"].isin(self.train_folds)],
+            meta[meta["fold"].isin(self.dev_folds)],
+            meta[meta["fold"].isin(self.test_folds)],
+        )
+
     @staticmethod
     def download(path: str) -> None:
         if os.path.exists(os.path.join(path, "default")):
@@ -23,12 +46,8 @@ class ESC50(BaseClassificationDataset):
             os.path.join(path, "ESC-50-master", "audio"),
             os.path.join(path, "default"),
         )
-
-        meta_path = os.path.join(path, "ESC-50-master", "meta", "esc50.csv")
-        meta = pd.read_csv(meta_path)
-
-        # Simple split only for demonstration purposes
-        meta[meta["fold"] < 4].to_csv(os.path.join(path, "train.csv"))
-        meta[meta["fold"] == 4].to_csv(os.path.join(path, "dev.csv"))
-        meta[meta["fold"] == 5].to_csv(os.path.join(path, "test.csv"))
+        shutil.move(
+            os.path.join(path, "ESC-50-master", "meta", "esc50.csv"),
+            path,
+        )
         shutil.rmtree(os.path.join(path, "ESC-50-master"))

--- a/docs/source/modules/datasets.rst
+++ b/docs/source/modules/datasets.rst
@@ -48,6 +48,20 @@ the :meth:`~autrainer.datasets.AbstractDataset.load_dataframes` method can be ov
 * :attr:`tracking_metric`: The :ref:`metric <metrics>` to track for early stopping and model selection.
 * :attr:`transform`: The :ref:`online transforms <online_transforms>` to apply to the data and the output :attr:`type` of the dataset.
 
+.. note::
+
+   The following attributes are automatically passed to the dataset during initialization and determined at runtime:
+   
+   * :attr:`train_transform`, :attr:`dev_transform`, and :attr:`test_transform`: The :class:`~autrainer.transforms.SmartCompose`
+     transformation pipelines (which may include possible :ref:`online transforms <online_transforms>` or :ref:`augmentations <augmentations>`).
+   * :attr:`seed`: The random seed for reproducibility during training.
+   * :attr:`batch_size`, :attr:`inference_batch_size`: The batch sizes for training and inference (dev, test).
+
+   The :attr:`transform` attribute in the configuration is not passed to the dataset during initialization
+   and is used to specify the :ref:`type of data <online_transforms>` the dataset provides as well as any
+   :ref:`online transforms <online_transforms>` to be applied to the data at runtime.
+
+
 To avoid race conditions when using :ref:`hydra_launcher_plugins` that may run multiple training jobs in parallel,
 :ref:`autrainer fetch <cli_autrainer_fetch>` and :ref:`autrainer preprocess <cli_preprocessing>`
 or :meth:`~autrainer.cli.fetch` and :meth:`~autrainer.cli.preprocess`

--- a/docs/source/modules/datasets.rst
+++ b/docs/source/modules/datasets.rst
@@ -4,27 +4,42 @@ Datasets
 ========
 
 `autrainer` provides a number of different audio-specific datasets, base datasets for different tasks, and toy datasets for testing purposes.
+To ensure consistency across different data formats and manage multiple data types, all datasets should follow a standardized structure.
 
 .. tip::
 
    To create custom datasets, refer to the :ref:`custom datasets tutorial <tut_datasets>`.
 
 
-A dataset configuration file should include the following attributes, in addition to the common attributes like :attr:`id`, :attr:`_target_`,
-and dataset-specific attributes inferred from the constructors:
+In addition to the common attributes like :attr:`id`, :attr:`_target_`, the dataset configuration file should include the following attributes:
 
 **Structure and Loading**
 
-* :attr:`path`: The directory path to the dataset, containing the :attr:`features_subdir` directory
-  and the :file:`train.csv`, :file:`dev.csv`, and :file:`test.csv` files.
-* :attr:`features_subdir`: The subdirectory within the dataset directory where (extracted) features are stored.
-  If different from `default` and set to the name of a :ref:`preprocessing transform <preprocessing_transforms>`,
-  :ref:`autrainer preprocess <cli_preprocessing>` will save the processed data in the specified subdirectory with the same name.
-* :attr:`index_column`: The column in the CSV files that contains paths to the audio files,
-  relative to the dataset subdirectory.
-* :attr:`target_column`: The column in the CSV files that contains the targets or labels.
-* :attr:`file_type`: The type of the files to load (e.g., `wav`, `npy`).
-* :attr:`file_handler`: The :ref:`file handler <dataset_file_handlers>` to use for loading the data.
+* :attr:`path`: Directory path containing the :attr:`features_subdir` directory and corresponding CSV files
+  (such as :file:`train.csv`, :file:`dev.csv`, and :file:`test.csv`).
+* :attr:`features_subdir`: The subdirectory within the dataset path where (extracted) features are stored.
+
+  * If no preprocessing is used (e.g., for raw audio), it should be :attr:`default`.
+  * For :ref:`preprocessing transforms <preprocessing_transforms>` (e.g., log-Mel spectrograms with :attr:`log_mel_16k`),
+    it should match the transform's name, and the processed features are saved in this subdirectory after preprocessing.
+
+* :attr:`index_column`: Column in the CSV files containing the file paths, relative to the :attr:`features_subdir` directory.
+* :attr:`target_column`: Column in the CSV files containing the corresponding targets or labels for each file.
+* :attr:`file_type`: Specifies the type of files to be loaded (e.g., :attr:`wav`, :attr:`npy`, etc.).
+* :attr:`file_handler`: The :ref:`file handler <dataset_file_handlers>` used for loading the files.
+
+This results in a directory structure like the following:
+
+.. code-block:: python
+
+   {path}/{features_subdir}/optional/subdirs/some.file
+
+
+For instance, a file in the :attr:`index_column` might be :file:`optional/subdirs/some.file`,
+where :file:`some.file` is an audio or a feature file.
+
+In order to load custom dataset splits that do not follow the standard :file:`train.csv`, :file:`dev.csv`, and :file:`test.csv` convention,
+the :meth:`~autrainer.datasets.AbstractDataset.load_dataframes` method can be overwritten (see :ref:`custom datasets tutorial <tut_datasets>`).
 
 **Training and Evaluation**
 
@@ -33,19 +48,16 @@ and dataset-specific attributes inferred from the constructors:
 * :attr:`tracking_metric`: The :ref:`metric <metrics>` to track for early stopping and model selection.
 * :attr:`transform`: The :ref:`online transforms <online_transforms>` to apply to the data and the output :attr:`type` of the dataset.
 
-
 To avoid race conditions when using :ref:`hydra_launcher_plugins` that may run multiple training jobs in parallel,
 :ref:`autrainer fetch <cli_autrainer_fetch>` and :ref:`autrainer preprocess <cli_preprocessing>`
 or :meth:`~autrainer.cli.fetch` and :meth:`~autrainer.cli.preprocess`
 are used to download the dataset and preprocess the data before training.
-
 
 .. note::
 
    All datasets that are provided by `autrainer` can be automatically downloaded as well as optionally preprocessed using the
    :ref:`autrainer fetch <cli_autrainer_fetch>` and :ref:`autrainer preprocess <cli_preprocessing>` CLI commands or the
    :meth:`~autrainer.cli.fetch` and :meth:`~autrainer.cli.preprocess` CLI wrapper functions.
-
 
 
 Abstract Dataset

--- a/docs/source/usage/tutorials.rst
+++ b/docs/source/usage/tutorials.rst
@@ -140,18 +140,6 @@ This dataset assumes that the :file:`data/SpectrogramDataset` directory contains
 * :file:`train.csv`, :file:`dev.csv`, and :file:`test.csv` files containing the file paths relative to the :file:`default/` directory
   in the :attr:`index_column` column and the corresponding labels in the :attr:`target_column` column.
 
-.. note::
-
-   The following attributes are automatically passed to the dataset during initialization and determined at runtime:
-   
-   * :attr:`train_transform`, :attr:`dev_transform`, and :attr:`test_transform`: The :class:`~autrainer.transforms.SmartCompose`
-     transformation pipelines (which may include possible :ref:`online transforms <online_transforms>` or :ref:`augmentations <augmentations>`).
-   * :attr:`seed`: The random seed for reproducibility during training.
-   * :attr:`batch_size`, :attr:`inference_batch_size`: The batch sizes for training and inference (dev, test).
-
-   The :attr:`transform` attribute in the configuration is not passed to the dataset during initialization
-   and is used to specify the :ref:`type of data <online_transforms>` the dataset provides as well as any
-   :ref:`online transforms <online_transforms>` to be applied to the data at runtime.
 
 .. _tut_metrics:
 

--- a/docs/source/usage/tutorials.rst
+++ b/docs/source/usage/tutorials.rst
@@ -97,9 +97,11 @@ For example, the `ESC-50 <https://github.com/karolpiczak/ESC-50>`_ dataset is an
    :linenos:
 
 The dataset provides audio files by default (which are moved to the :file:`default/` directory in the
-:meth:`~autrainer.datasets.AbstractDataset.download` method).
-As the resulting dataset structure follows the standard format outlined in the :ref:`dataset documentation <datasets>`,
-no further implementation or overrides are necessary.
+:meth:`~autrainer.datasets.AbstractDataset.download` method) and the corresponding metadata of the dataset is stored in the :file:`esc50.csv` file.
+
+To allow the the specification of custom folds, the :meth:`~autrainer.datasets.AbstractDataset.load_dataframes`
+method is overridden to split the :file:`esc50.csv` file into the respective train, dev, and test dataframes.
+This also allows for cross-validation by creating multiple configurations with different folds.
 
 To extract log-Mel spectrograms from the audio files, a :ref:`preprocessing transform <preprocessing_transforms>`
 can be applied to the data before training.


### PR DESCRIPTION
Closes #28 and provide several improvements of the dataset-related documentation:
- explain the default dataset structure in more detail
- extend the custom datasets tutorial to include a cross-validation example by overriding the `load_dataframes` method
- move runtime arguments note to the datasets documentation