### PR TITLE
Add Inference Progress Bars

### DIFF
--- a/autrainer/core/scripts/inference_script.py
+++ b/autrainer/core/scripts/inference_script.py
@@ -20,6 +20,7 @@ class InferenceArgs:
     extension: str
     recursive: bool
     embeddings: bool
+    frequency: int
     preprocess_cfg: Optional[str]
     window_length: Optional[float]
     stride_length: Optional[float]
@@ -123,7 +124,18 @@ class InferenceScript(AbstractScript):
                 "Defaults to False."
             ),
         )
-
+        self.parser.add_argument(
+            "-f",
+            "--frequency",
+            type=int,
+            default=1,
+            metavar="F",
+            required=False,
+            help=(
+                "Frequency of progress bar updates. "
+                "If 0, the progress bar will be disabled. Defaults to 1."
+            ),
+        )
         self.parser.add_argument(
             "-p",
             "--preprocess-cfg",
@@ -324,6 +336,7 @@ class InferenceScript(AbstractScript):
             args.input,
             extension=args.extension,
             recursive=args.recursive,
+            frequency=args.frequency,
         )
         inference.save_prediction_yaml(results, args.output)
         inference.save_prediction_results(results, args.output)
@@ -335,6 +348,7 @@ class InferenceScript(AbstractScript):
             args.input,
             extension=args.extension,
             recursive=args.recursive,
+            frequency=args.frequency,
         )
         inference.save_embeddings(
             results,
@@ -353,6 +367,7 @@ def inference(
     extension: str = "wav",
     recursive: bool = False,
     embeddings: bool = False,
+    frequency: int = 1,
     preprocess_cfg: Optional[str] = "default",
     window_length: Optional[float] = None,
     stride_length: Optional[float] = None,
@@ -383,6 +398,8 @@ def inference(
         embeddings: Extract embeddings from the model in addition to
             predictions. For each file, a .pt file with embeddings will be
             saved. Defaults to False.
+        frequency: Frequency of progress bar updates. If 0, the progress bar
+            will be disabled. Defaults to 1.
         preprocess_cfg: Preprocessing configuration to apply to input. Can be
             a path to a YAML file or the name of the preprocessing
             configuration in the local or autrainer 'conf/preprocessing'
@@ -417,6 +434,7 @@ def inference(
             extension,
             recursive,
             embeddings,
+            frequency,
             preprocess_cfg,
             window_length,
             stride_length,

--- a/autrainer/core/scripts/inference_script.py
+++ b/autrainer/core/scripts/inference_script.py
@@ -20,7 +20,7 @@ class InferenceArgs:
     extension: str
     recursive: bool
     embeddings: bool
-    frequency: int
+    update_frequency: int
     preprocess_cfg: Optional[str]
     window_length: Optional[float]
     stride_length: Optional[float]
@@ -125,8 +125,8 @@ class InferenceScript(AbstractScript):
             ),
         )
         self.parser.add_argument(
-            "-f",
-            "--frequency",
+            "-u",
+            "--update-frequency",
             type=int,
             default=1,
             metavar="F",
@@ -336,7 +336,7 @@ class InferenceScript(AbstractScript):
             args.input,
             extension=args.extension,
             recursive=args.recursive,
-            frequency=args.frequency,
+            update_frequency=args.update_frequency,
         )
         inference.save_prediction_yaml(results, args.output)
         inference.save_prediction_results(results, args.output)
@@ -348,7 +348,7 @@ class InferenceScript(AbstractScript):
             args.input,
             extension=args.extension,
             recursive=args.recursive,
-            frequency=args.frequency,
+            update_frequency=args.update_frequency,
         )
         inference.save_embeddings(
             results,
@@ -367,7 +367,7 @@ def inference(
     extension: str = "wav",
     recursive: bool = False,
     embeddings: bool = False,
-    frequency: int = 1,
+    update_frequency: int = 1,
     preprocess_cfg: Optional[str] = "default",
     window_length: Optional[float] = None,
     stride_length: Optional[float] = None,
@@ -398,8 +398,8 @@ def inference(
         embeddings: Extract embeddings from the model in addition to
             predictions. For each file, a .pt file with embeddings will be
             saved. Defaults to False.
-        frequency: Frequency of progress bar updates. If 0, the progress bar
-            will be disabled. Defaults to 1.
+        update_frequency: Frequency of progress bar updates. If 0, the progress
+            bar will be disabled. Defaults to 1.
         preprocess_cfg: Preprocessing configuration to apply to input. Can be
             a path to a YAML file or the name of the preprocessing
             configuration in the local or autrainer 'conf/preprocessing'
@@ -434,7 +434,7 @@ def inference(
             extension,
             recursive,
             embeddings,
-            frequency,
+            update_frequency,
             preprocess_cfg,
             window_length,
             stride_length,

--- a/autrainer/core/scripts/preprocess_script.py
+++ b/autrainer/core/scripts/preprocess_script.py
@@ -21,8 +21,7 @@ from .utils import (
 @dataclass
 class PreprocessArgs(PreprocessArgs):
     num_workers: int
-    pbar_frequency: int
-    silent: bool
+    frequency: int
 
 
 class PreprocessScript(AbstractPreprocessScript):
@@ -54,21 +53,16 @@ class PreprocessScript(AbstractPreprocessScript):
             ),
         )
         self.parser.add_argument(
-            "-p",
-            "--pbar-frequency",
+            "-f",
+            "--frequency",
             type=int,
-            default=100,
-            metavar="P",
+            default=1,
+            metavar="F",
             required=False,
-            help="Frequency of progress bar updates. Defaults to 100.",
-        )
-        self.parser.add_argument(
-            "-s",
-            "--silent",
-            action="store_true",
-            default=False,
-            required=False,
-            help="Disable progress bar output.",
+            help=(
+                "Frequency of progress bar updates for each worker. "
+                "If 0, the progress bar will be disabled. Defaults to 1."
+            ),
         )
 
     def main(self, args: PreprocessArgs) -> None:
@@ -77,8 +71,7 @@ class PreprocessScript(AbstractPreprocessScript):
         import hydra
 
         self.num_workers = args.num_workers
-        self.pbar_frequency = args.pbar_frequency
-        self.silent = args.silent
+        self.frequency = args.frequency
         self._override_launcher(args)
         self.datasets = {}
         self.preprocessing = {}
@@ -192,11 +185,11 @@ class PreprocessScript(AbstractPreprocessScript):
                 output_file_handler.save(out_path, data)
                 del data
                 file_count += 1
-                if file_count % self.pbar_frequency == 0:
+                if file_count % self.frequency == 0:
                     with lock:
-                        pbar.update(self.pbar_frequency)
+                        pbar.update(self.frequency)
             with lock:
-                pbar.update(file_count % self.pbar_frequency)
+                pbar.update(file_count % self.frequency)
 
         print("Preprocessing datasets...")
         for (name, dataset), preprocess in zip(
@@ -220,7 +213,7 @@ class PreprocessScript(AbstractPreprocessScript):
             with tqdm(
                 total=len(unique_files),
                 desc=name,
-                disable=self.silent,
+                disable=self.frequency == 0,
             ) as pbar:
                 with ThreadPoolExecutor(self.num_workers) as executor:
                     futures = [
@@ -242,8 +235,7 @@ class PreprocessScript(AbstractPreprocessScript):
 def preprocess(
     override_kwargs: Optional[dict] = None,
     num_workers: int = 1,
-    pbar_frequency: int = 100,
-    silent: bool = False,
+    frequency: int = 100,
     cfg_launcher: bool = False,
     config_name: str = "config",
     config_path: Optional[str] = None,
@@ -255,8 +247,8 @@ def preprocess(
             train script.
         num_workers: Number of workers (threads) to use for preprocessing.
             Defaults to 1.
-        pbar_frequency: Frequency of progress bar updates. Defaults to 100.
-        silent: Disable progress bar output. Defaults to False.
+        frequency: Frequency of progress bar updates for each worker. If 0, the
+            progress bar will be disabled. Defaults to 1.
         cfg_launcher: Use the launcher specified in the configuration instead
             of the Hydra basic launcher. Defaults to False.
         config_name: The name of the config (usually the file name without the
@@ -269,15 +261,11 @@ def preprocess(
         cmd = "preprocess"
         if cfg_launcher:
             cmd += " -l"
-        if silent:
-            cmd += " -s"
-        cmd += f" -n {num_workers} -p {pbar_frequency}"
+        cmd += f" -n {num_workers} -f {frequency}"
         run_hydra_cmd(cmd, override_kwargs, config_name, config_path)
 
     else:
         add_hydra_args_to_sys(override_kwargs, config_name, config_path)
         script = PreprocessScript()
         script.parser = MockParser()
-        script.main(
-            PreprocessArgs(cfg_launcher, num_workers, pbar_frequency, silent)
-        )
+        script.main(PreprocessArgs(cfg_launcher, num_workers, frequency))

--- a/autrainer/core/scripts/preprocess_script.py
+++ b/autrainer/core/scripts/preprocess_script.py
@@ -235,7 +235,7 @@ class PreprocessScript(AbstractPreprocessScript):
 def preprocess(
     override_kwargs: Optional[dict] = None,
     num_workers: int = 1,
-    frequency: int = 100,
+    frequency: int = 1,
     cfg_launcher: bool = False,
     config_name: str = "config",
     config_path: Optional[str] = None,

--- a/autrainer/core/scripts/preprocess_script.py
+++ b/autrainer/core/scripts/preprocess_script.py
@@ -261,7 +261,7 @@ def preprocess(
         cmd = "preprocess"
         if cfg_launcher:
             cmd += " -l"
-        cmd += f" -n {num_workers} -f {update_frequency}"
+        cmd += f" -n {num_workers} -u {update_frequency}"
         run_hydra_cmd(cmd, override_kwargs, config_name, config_path)
 
     else:

--- a/autrainer/serving/serving.py
+++ b/autrainer/serving/serving.py
@@ -115,7 +115,7 @@ class Inference:
         directory: str,
         extension: str,
         recursive: bool = False,
-        frequency: int = 1,
+        update_frequency: int = 1,
     ) -> pd.DataFrame:
         """Obtain the model predictions for all files in a directory.
 
@@ -124,8 +124,8 @@ class Inference:
             extension: File extension of the audio files.
             recursive: Whether to search recursively for audio files in
                 subdirectories. Defaults to False.
-            frequency: Frequency of progress bar updates. If 0, the progress
-                bar will be disabled. Defaults to 1.
+            update_frequency: Frequency of progress bar updates. If 0, the
+                progress bar will be disabled. Defaults to 1.
 
         Returns:
             DataFrame containing the filename, prediction, and output for
@@ -136,8 +136,8 @@ class Inference:
         records = []
         for file in tqdm(
             files,
-            disable=frequency == 0,
-            miniters=frequency,
+            disable=update_frequency == 0,
+            miniters=update_frequency,
             desc="Inference prediction",
         ):
             prediction, output = self.predict_file(file)
@@ -168,7 +168,7 @@ class Inference:
         directory: str,
         extension: str,
         recursive: bool = False,
-        frequency: int = 1,
+        update_frequency: int = 1,
     ) -> pd.DataFrame:
         """Obtain the model embeddings for all files in a directory.
 
@@ -177,8 +177,8 @@ class Inference:
             extension: File extension of the audio files.
             recursive: Whether to search recursively for audio files in
                 subdirectories. Defaults to False.
-            frequency: Frequency of progress bar updates. If 0, the progress
-                bar will be disabled. Defaults to 1.
+            update_frequency: Frequency of progress bar updates. If 0, the
+            progress bar will be disabled. Defaults to 1.
 
         Returns:
             DataFrame containing the filename and embedding for each file.
@@ -189,8 +189,8 @@ class Inference:
         records = []
         for file in tqdm(
             files,
-            disable=frequency == 0,
-            miniters=frequency,
+            disable=update_frequency == 0,
+            miniters=update_frequency,
             desc="Inference embedding",
         ):
             embedding = self.embed_file(file)

--- a/autrainer/serving/serving.py
+++ b/autrainer/serving/serving.py
@@ -8,6 +8,7 @@ import audobject
 from omegaconf import OmegaConf
 import pandas as pd
 import torch
+from tqdm import tqdm
 import yaml
 
 import autrainer
@@ -114,6 +115,7 @@ class Inference:
         directory: str,
         extension: str,
         recursive: bool = False,
+        frequency: int = 1,
     ) -> pd.DataFrame:
         """Obtain the model predictions for all files in a directory.
 
@@ -122,6 +124,8 @@ class Inference:
             extension: File extension of the audio files.
             recursive: Whether to search recursively for audio files in
                 subdirectories. Defaults to False.
+            frequency: Frequency of progress bar updates. If 0, the progress
+                bar will be disabled. Defaults to 1.
 
         Returns:
             DataFrame containing the filename, prediction, and output for
@@ -130,7 +134,12 @@ class Inference:
         """
         files = self._collect_files(directory, extension, recursive)
         records = []
-        for file in files:
+        for file in tqdm(
+            files,
+            disable=frequency == 0,
+            miniters=frequency,
+            desc="Inference prediction",
+        ):
             prediction, output = self.predict_file(file)
             if isinstance(prediction, dict):
                 for (offset, pred), out in zip(
@@ -159,6 +168,7 @@ class Inference:
         directory: str,
         extension: str,
         recursive: bool = False,
+        frequency: int = 1,
     ) -> pd.DataFrame:
         """Obtain the model embeddings for all files in a directory.
 
@@ -167,6 +177,8 @@ class Inference:
             extension: File extension of the audio files.
             recursive: Whether to search recursively for audio files in
                 subdirectories. Defaults to False.
+            frequency: Frequency of progress bar updates. If 0, the progress
+                bar will be disabled. Defaults to 1.
 
         Returns:
             DataFrame containing the filename and embedding for each file.
@@ -175,7 +187,12 @@ class Inference:
         """
         files = self._collect_files(directory, extension, recursive)
         records = []
-        for file in files:
+        for file in tqdm(
+            files,
+            disable=frequency == 0,
+            miniters=frequency,
+            desc="Inference embedding",
+        ):
             embedding = self.embed_file(file)
             if isinstance(embedding, dict):
                 for offset, emb in embedding.items():

--- a/tests/test_cli_wrapper.py
+++ b/tests/test_cli_wrapper.py
@@ -259,10 +259,7 @@ class TestCLIFetch(BaseIndividualTempDir):
 class TestCLIPreprocess(BaseIndividualTempDir):
     def test_preprocess(self, capfd: pytest.CaptureFixture) -> None:
         with patch("sys.argv", [""]):
-            autrainer.cli.preprocess(
-                cfg_launcher=True,
-                silent=True,
-            )
+            autrainer.cli.preprocess(cfg_launcher=True, frequency=0)
         out, _ = capfd.readouterr()
         assert (
             "Preprocessing datasets..." in out

--- a/tests/test_cli_wrapper.py
+++ b/tests/test_cli_wrapper.py
@@ -259,7 +259,7 @@ class TestCLIFetch(BaseIndividualTempDir):
 class TestCLIPreprocess(BaseIndividualTempDir):
     def test_preprocess(self, capfd: pytest.CaptureFixture) -> None:
         with patch("sys.argv", [""]):
-            autrainer.cli.preprocess(cfg_launcher=True, frequency=0)
+            autrainer.cli.preprocess(cfg_launcher=True, update_frequency=0)
         out, _ = capfd.readouterr()
         assert (
             "Preprocessing datasets..." in out


### PR DESCRIPTION
This adds numerous progress bar improvements:
-  added tqdm progress bars to both `Inference.predict_directory` and `Inference.embed_directory`, controllable via the `-f, --frequency` argument. If set to 0, the progress bar is disabled.
-  merged the `pbar_frequency` and `silent` attributes to `frequency` for `autrainer preprocess` with the same functionality as well such that the CLI and Python wrappers are consistent for all commands / functions.
- adjusted the `frequency` to 1 by default, which should align more with what a user would expect by default.