### PR TITLE
Add License to Footer in Documentation

### DIFF
--- a/docs/source/conf.py
+++ b/docs/source/conf.py
@@ -19,7 +19,7 @@ sys.path.append(os.path.abspath("../extensions"))
 project = pyroject["tool"]["poetry"]["name"]
 description = pyroject["tool"]["poetry"]["description"]
 author = build_authors(pyroject["tool"]["poetry"]["authors"])
-copyright = f"{datetime.datetime.now().year}, {author}"
+copyright = f"{datetime.datetime.now().year} (MIT) {author}"
 release = pyroject["tool"]["poetry"]["version"]
 
 

--- a/docs/source/usage/cli_reference.rst
+++ b/docs/source/usage/cli_reference.rst
@@ -106,7 +106,7 @@ Preprocessing
 -------------
 
 To avoid race conditions when using :ref:`hydra_launcher_plugins` that may run multiple training jobs in parallel,
-:ref:`autrainer fetch <cli_autrainer_fetch>` and :ref:`autrainer preprocess <cli_autrainer_preprocess>` are allow for the
+:ref:`autrainer fetch <cli_autrainer_fetch>` and :ref:`autrainer preprocess <cli_autrainer_preprocess>` allow for
 downloading and :ref:`preprocessing <preprocessing_transforms>` of :ref:`datasets` (and pretrained model states) before training.
 
 Both commands are based on the :ref:`main configuration <main_configuration>` file (e.g. :file:`conf/config.yaml`),

--- a/docs/source/usage/cli_wrapper.rst
+++ b/docs/source/usage/cli_wrapper.rst
@@ -50,7 +50,7 @@ Preprocessing
 -------------
 
 To avoid race conditions when using :ref:`hydra_launcher_plugins` that may run multiple training jobs in parallel,
-:meth:`~autrainer.cli.fetch` and :meth:`~autrainer.cli.preprocess` are allow for the
+:meth:`~autrainer.cli.fetch` and :meth:`~autrainer.cli.preprocess` allow for
 downloading and :ref:`preprocessing <preprocessing_transforms>` of :ref:`datasets` (and pretrained model states) before training.
 
 Both commands are based on the :ref:`main configuration <main_configuration>` file (e.g. :file:`conf/config.yaml`),


### PR DESCRIPTION
This includes the MIT license in the footer before the authors (in addition to the license badge in the README).
Also fixes a small typo in the docs.