### PR TITLE
Fix Empty Class Prediction for MultiLabelEncoder 

### DIFF
--- a/autrainer/datasets/utils/target_transforms.py
+++ b/autrainer/datasets/utils/target_transforms.py
@@ -167,6 +167,8 @@ class MultiLabelEncoder(AbstractTargetTransform):
         Returns:
             Binary tensor of encoded target labels.
         """
+        if len(x) == 0:
+            return torch.zeros(len(self.labels))
         if isinstance(x, (torch.Tensor, np.ndarray)) or all(
             isinstance(i, (int, float)) for i in x
         ):

--- a/autrainer/serving/serving.py
+++ b/autrainer/serving/serving.py
@@ -314,14 +314,14 @@ class Inference:
         pattern = f"**/*.{extension}" if recursive else f"*.{extension}"
         return glob.glob(os.path.join(directory, pattern), recursive=True)
 
-    def _preprocess_file(self, x: Union[torch.Tensor]) -> torch.Tensor:
+    def _preprocess_file(self, x: torch.Tensor) -> torch.Tensor:
         x = self._pad_audio(x)
         x = self.preprocess_pipeline(x, 0)
         x = self.inference_transform(x, 0)
         x = x.unsqueeze(0).to(self._device)
         return x
 
-    def _predict(self, x: Union[torch.Tensor]) -> Tuple[Any, torch.Tensor]:
+    def _predict(self, x: torch.Tensor) -> Tuple[Any, torch.Tensor]:
         x = self._preprocess_file(x)
         with torch.inference_mode():
             output = self.model(x).cpu()
@@ -329,7 +329,7 @@ class Inference:
         prediction = self.target_transform.decode(prediction)
         return prediction, output
 
-    def _embed(self, x: Union[torch.Tensor]) -> torch.Tensor:
+    def _embed(self, x: torch.Tensor) -> torch.Tensor:
         x = self._preprocess_file(x)
         with torch.inference_mode():
             embedding = self.model.embeddings(x).cpu().squeeze()
@@ -343,7 +343,7 @@ class Inference:
 
     def _predict_windowed(
         self,
-        x: Union[torch.Tensor],
+        x: torch.Tensor,
     ) -> Tuple[Dict[str, Any], Dict[str, torch.Tensor]]:
         results = {}
         outputs = {}
@@ -361,10 +361,7 @@ class Inference:
         outputs["majority"] = torch.empty(0)
         return results, outputs
 
-    def _embed_windowed(
-        self,
-        x: Union[torch.Tensor],
-    ) -> Dict[str, torch.Tensor]:
+    def _embed_windowed(self, x: torch.Tensor) -> Dict[str, torch.Tensor]:
         results = {}
         w_len, s_len, num_windows = self._create_windows(x)
         for i in range(num_windows):
@@ -376,7 +373,7 @@ class Inference:
             results[f"{start_time:.2f}-{end_time:.2f}"] = embedding
         return results
 
-    def _pad_audio(self, x: Union[torch.Tensor]) -> Union[torch.Tensor]:
+    def _pad_audio(self, x: torch.Tensor) -> torch.Tensor:
         if not self._min_length:
             return x
         min_length = int(self._min_length * self._sample_rate)

--- a/tests/test_dataset_utils.py
+++ b/tests/test_dataset_utils.py
@@ -110,6 +110,18 @@ class TestMultiLabelEncoder:
             "jazz",
         ], "Should encode and decode."
 
+    def test_empty_encode(self) -> None:
+        encoder = MultiLabelEncoder(0.5, self.labels)
+        assert torch.all(
+            encoder([]) == torch.zeros(3)
+        ), "Should encode an empty list."
+
+    def test_empty_decode(self) -> None:
+        encoder = MultiLabelEncoder(0.5, self.labels)
+        assert (
+            encoder.decode(encoder([]).tolist()) == []
+        ), "Should decode an empty list."
+
     def test_predict_batch(self) -> None:
         encoder = MultiLabelEncoder(0.5, self.labels)
         x = torch.Tensor([-0.1, 0.9, 0.6])


### PR DESCRIPTION
This fixes a bug when a model predicts no class being present for a sample in a mulit-label classification setting.
`MultiLabelEncoder.encode` returned an empty tensor instead of the expected zeros tensor, leading to a jagged array during `MultiLabelEncoder.majority_vote`.