### PR TITLE
Remove Optional Sigmoid and Softmax from Models

### DIFF
--- a/autrainer-configurations/model/Seq-FFNN-IS09.yaml
+++ b/autrainer-configurations/model/Seq-FFNN-IS09.yaml
@@ -6,8 +6,6 @@ backbone_hidden_size: 32
 backbone_num_layers: 2
 hidden_size: 32
 num_layers: 2
-sigmoid: false
-softmax: false
 dropout: 0.5
 
 transform:

--- a/autrainer-configurations/model/Seq-FFNN-IS10.yaml
+++ b/autrainer-configurations/model/Seq-FFNN-IS10.yaml
@@ -6,8 +6,6 @@ backbone_hidden_size: 32
 backbone_num_layers: 2
 hidden_size: 32
 num_layers: 2
-sigmoid: false
-softmax: false
 dropout: 0.5
 
 transform:

--- a/autrainer-configurations/model/Seq-FFNN-IS11.yaml
+++ b/autrainer-configurations/model/Seq-FFNN-IS11.yaml
@@ -6,8 +6,6 @@ backbone_hidden_size: 32
 backbone_num_layers: 2
 hidden_size: 32
 num_layers: 2
-sigmoid: false
-softmax: false
 dropout: 0.5
 
 transform:

--- a/autrainer-configurations/model/Seq-FFNN-IS12.yaml
+++ b/autrainer-configurations/model/Seq-FFNN-IS12.yaml
@@ -6,8 +6,6 @@ backbone_hidden_size: 32
 backbone_num_layers: 2
 hidden_size: 32
 num_layers: 2
-sigmoid: false
-softmax: false
 dropout: 0.5
 
 transform:

--- a/autrainer-configurations/model/Seq-FFNN-IS13.yaml
+++ b/autrainer-configurations/model/Seq-FFNN-IS13.yaml
@@ -6,8 +6,6 @@ backbone_hidden_size: 32
 backbone_num_layers: 2
 hidden_size: 32
 num_layers: 2
-sigmoid: false
-softmax: false
 dropout: 0.5
 
 transform:

--- a/autrainer-configurations/model/Seq-FFNN-IS16.yaml
+++ b/autrainer-configurations/model/Seq-FFNN-IS16.yaml
@@ -6,8 +6,6 @@ backbone_hidden_size: 32
 backbone_num_layers: 2
 hidden_size: 32
 num_layers: 2
-sigmoid: false
-softmax: false
 dropout: 0.5
 
 transform:

--- a/autrainer-configurations/model/Seq-FFNN-eGeMAPS.yaml
+++ b/autrainer-configurations/model/Seq-FFNN-eGeMAPS.yaml
@@ -6,8 +6,6 @@ backbone_hidden_size: 32
 backbone_num_layers: 2
 hidden_size: 32
 num_layers: 2
-sigmoid: false
-softmax: false
 dropout: 0.5
 
 transform:

--- a/autrainer-configurations/model/Whisper-FFNN-Base-T.yaml
+++ b/autrainer-configurations/model/Whisper-FFNN-Base-T.yaml
@@ -3,8 +3,6 @@ _target_: autrainer.models.WhisperFFNN
 model_name: openai/whisper-base
 hidden_size: 512
 num_layers: 2
-sigmoid: false
-softmax: false
 dropout: 0.5
 
 transform:

--- a/autrainer-configurations/model/Whisper-FFNN-Small-T.yaml
+++ b/autrainer-configurations/model/Whisper-FFNN-Small-T.yaml
@@ -3,8 +3,6 @@ _target_: autrainer.models.WhisperFFNN
 model_name: openai/whisper-small
 hidden_size: 512
 num_layers: 2
-sigmoid: false
-softmax: false
 dropout: 0.5
 
 transform:

--- a/autrainer-configurations/model/Whisper-FFNN-Tiny-T.yaml
+++ b/autrainer-configurations/model/Whisper-FFNN-Tiny-T.yaml
@@ -3,8 +3,6 @@ _target_: autrainer.models.WhisperFFNN
 model_name: openai/whisper-tiny
 hidden_size: 512
 num_layers: 2
-sigmoid: false
-softmax: false
 dropout: 0.5
 
 transform:

--- a/autrainer-configurations/model/hubert-b-ls960.yaml
+++ b/autrainer-configurations/model/hubert-b-ls960.yaml
@@ -4,8 +4,6 @@ model_name: facebook/hubert-base-ls960
 freeze_extractor: true
 hidden_size: 512
 num_layers: 2
-sigmoid: false
-softmax: false
 dropout: 0.5
 
 transform:

--- a/autrainer-configurations/model/hubert-l-ll60k.yaml
+++ b/autrainer-configurations/model/hubert-l-ll60k.yaml
@@ -4,8 +4,6 @@ model_name: facebook/hubert-large-ll60k
 freeze_extractor: true
 hidden_size: 512
 num_layers: 2
-sigmoid: false
-softmax: false
 dropout: 0.5
 
 transform:

--- a/autrainer-configurations/model/w2v2-b.yaml
+++ b/autrainer-configurations/model/w2v2-b.yaml
@@ -4,8 +4,6 @@ model_name: facebook/wav2vec2-base
 freeze_extractor: true
 hidden_size: 512
 num_layers: 2
-sigmoid: false
-softmax: false
 dropout: 0.5
 
 transform:

--- a/autrainer-configurations/model/w2v2-l-100k.yaml
+++ b/autrainer-configurations/model/w2v2-l-100k.yaml
@@ -4,8 +4,6 @@ model_name: facebook/wav2vec2-large-100k-voxpopuli
 freeze_extractor: true
 hidden_size: 512
 num_layers: 2
-sigmoid: false
-softmax: false
 dropout: 0.5
 
 transform:

--- a/autrainer-configurations/model/w2v2-l-emo.yaml
+++ b/autrainer-configurations/model/w2v2-l-emo.yaml
@@ -4,8 +4,6 @@ model_name: audeering/wav2vec2-large-robust-12-ft-emotion-msp-dim
 freeze_extractor: true
 hidden_size: 512
 num_layers: 2
-sigmoid: false
-softmax: false
 dropout: 0.5
 
 transform:

--- a/autrainer-configurations/model/w2v2-l-rob.yaml
+++ b/autrainer-configurations/model/w2v2-l-rob.yaml
@@ -4,8 +4,6 @@ model_name: facebook/wav2vec2-large-robust
 freeze_extractor: true
 hidden_size: 512
 num_layers: 2
-sigmoid: false
-softmax: false
 dropout: 0.5
 
 transform:

--- a/autrainer-configurations/model/w2v2-l.yaml
+++ b/autrainer-configurations/model/w2v2-l.yaml
@@ -4,8 +4,6 @@ model_name: facebook/wav2vec2-large
 freeze_extractor: true
 hidden_size: 512
 num_layers: 2
-sigmoid: false
-softmax: false
 dropout: 0.5
 
 transform:

--- a/autrainer/models/ast_model.py
+++ b/autrainer/models/ast_model.py
@@ -14,7 +14,6 @@ class ASTModel(AbstractModel):
         num_hidden_layers: int = 12,
         hidden_size: int = 128,
         dropout: float = 0.5,
-        sigmoid: bool = False,
         transfer: Optional[str] = None,
     ) -> None:
         """Audio Speech Transformer (AST) model. For more information see:
@@ -26,8 +25,6 @@ class ASTModel(AbstractModel):
                 Defaults to 12.
             hidden_size: Hidden size of the linear layer. Defaults to 128.
             dropout: Dropout rate. Defaults to 0.5.
-            sigmoid: If True, a sigmoid activation function is applied to the
-                output. Defaults to False.
             transfer: Name of the pretrained model to load. If None, the default
                 AST fine-tuned on AudioSet is used. Defaults to None.
                 For more information see:
@@ -37,7 +34,6 @@ class ASTModel(AbstractModel):
         self.num_hidden_layers = num_hidden_layers
         self.hidden_size = hidden_size
         self.dropout = dropout
-        self.sigmoid = sigmoid
         self.transfer = transfer
         if self.transfer is not None:
             self.model = ASTBaseModel.from_pretrained(
@@ -55,8 +51,6 @@ class ASTModel(AbstractModel):
             torch.nn.Dropout(dropout),
             torch.nn.Linear(hidden_size, output_dim),
         ]
-        if self.sigmoid:
-            layers.append(torch.nn.Sigmoid())
         self.out = torch.nn.Sequential(*layers)
 
     def embeddings(self, x: torch.Tensor) -> torch.Tensor:

--- a/autrainer/models/cnn_10.py
+++ b/autrainer/models/cnn_10.py
@@ -11,8 +11,6 @@ class Cnn10(AbstractModel):
     def __init__(
         self,
         output_dim: int,
-        sigmoid_output: bool = False,
-        sigmoid_predictions: bool = False,
         segmentwise: bool = False,
         in_channels: int = 1,
         transfer: Optional[str] = None,
@@ -22,10 +20,6 @@ class Cnn10(AbstractModel):
 
         Args:
             output_dim: Output dimension of the model.
-            sigmoid_output: Whether to apply sigmoid activation to the output.
-                Defaults to False.
-            sigmoid_predictions: Whether to apply sigmoid activation during
-                inference. Defaults to False.
             segmentwise: Whether to use segmentwise path or clipwise path.
                 Defaults to False.
             in_channels: Number of input channels. Defaults to 1.
@@ -33,8 +27,6 @@ class Cnn10(AbstractModel):
                 weights will be randomly initialized. Defaults to None.
         """
         super().__init__(output_dim)
-        self.sigmoid_output = sigmoid_output
-        self.sigmoid_predictions = sigmoid_predictions
         self.segmentwise = segmentwise
         self.in_channels = in_channels
         self.transfer = transfer
@@ -101,10 +93,4 @@ class Cnn10(AbstractModel):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         x = self.embeddings(x)
         x = self.out(x)
-        if self.sigmoid_output:
-            x = torch.sigmoid(x)
-        if (not self.training) and self.sigmoid_predictions:
-            # sigmoid output for multi-label classification
-            if not self.sigmoid_output:  # avoid double op
-                x = torch.sigmoid(x)
         return x

--- a/autrainer/models/cnn_14.py
+++ b/autrainer/models/cnn_14.py
@@ -11,7 +11,6 @@ class Cnn14(AbstractModel):
     def __init__(
         self,
         output_dim: int,
-        sigmoid_output: bool = False,
         segmentwise: bool = False,
         in_channels: int = 1,
         transfer: Optional[str] = None,
@@ -21,8 +20,6 @@ class Cnn14(AbstractModel):
 
         Args:
             output_dim: Output dimension of the model.
-            sigmoid_output: Whether to apply sigmoid activation to the output.
-                Defaults to False.
             segmentwise: Whether to use segmentwise path or clipwise path.
                 Defaults to False.
             in_channels: Number of input channels. Defaults to 1.
@@ -30,7 +27,6 @@ class Cnn14(AbstractModel):
                 weights will be randomly initialized. Defaults to None.
         """
         super().__init__(output_dim)
-        self.sigmoid_output = sigmoid_output
         self.segmentwise = segmentwise
         self.in_channels = in_channels
         self.transfer = transfer
@@ -103,6 +99,4 @@ class Cnn14(AbstractModel):
     def forward(self, x: torch.Tensor) -> torch.Tensor:
         x = self.embeddings(x)
         x = self.out(x)
-        if self.sigmoid_output:
-            x = torch.sigmoid(x)
         return x

--- a/autrainer/models/ffnn.py
+++ b/autrainer/models/ffnn.py
@@ -11,8 +11,6 @@ class FFNN(AbstractModel):
         input_size: int,
         hidden_size: int,
         num_layers: int = 2,
-        sigmoid: bool = False,
-        softmax: bool = False,
         dropout: float = 0.5,
     ) -> None:
         """Feedforward neural network.
@@ -22,16 +20,12 @@ class FFNN(AbstractModel):
             input_size: Input size.
             hidden_size: Hidden size.
             num_layers: Number of layers.
-            sigmoid: Whether to use sigmoid activation.
-            softmax: Whether to use softmax activation.
             dropout: Dropout rate.
         """
         super().__init__(output_dim)
         self.input_size = input_size
         self.hidden_size = hidden_size
         self.num_layers = num_layers
-        self.sigmoid = sigmoid
-        self.softmax = softmax
         self.dropout = dropout
 
         layers = []
@@ -49,10 +43,6 @@ class FFNN(AbstractModel):
                 torch.nn.Linear(layer_input, output_dim),
             )
         )
-        if self.sigmoid:
-            layers.append(("Sigmoid", torch.nn.Sigmoid()))
-        if self.softmax:
-            layers.append(("Softmax", torch.nn.Softmax(dim=1)))
 
         for name, layer in layers:
             self.add_module(name, layer)

--- a/autrainer/models/sequential.py
+++ b/autrainer/models/sequential.py
@@ -56,8 +56,6 @@ class SeqFFNN(AbstractModel):
         backbone_num_layers: int,
         hidden_size: int,
         num_layers: int = 2,
-        sigmoid: bool = False,
-        softmax: bool = False,
         dropout: float = 0.5,
         backbone_dropout: float = 0.5,
         backbone_cell: str = "LSTM",
@@ -73,8 +71,6 @@ class SeqFFNN(AbstractModel):
             backbone_num_layers: Number of layers of the backbone.
             hidden_size: Hidden size of the FFNN.
             num_layers: Number of layers of the FFNN. Defaults to 2.
-            sigmoid: Whether to apply sigmoid activation. Defaults to False.
-            softmax: Whether to apply softmax activation. Defaults to False.
             dropout: Dropout rate of the FFNN. Defaults to 0.5.
             backbone_dropout: Dropout rate of the backbone. Defaults to 0.5.
             backbone_cell: Cell type of the backbone in ["LSTM", "GRU"].
@@ -90,8 +86,6 @@ class SeqFFNN(AbstractModel):
         self.backbone_num_layers = backbone_num_layers
         self.hidden_size = hidden_size
         self.num_layers = num_layers
-        self.sigmoid = sigmoid
-        self.softmax = softmax
         self.dropout = dropout
         self.backbone_dropout = backbone_dropout
         self.backbone_cell = backbone_cell
@@ -111,8 +105,6 @@ class SeqFFNN(AbstractModel):
             hidden_size=hidden_size,
             output_dim=output_dim,
             num_layers=num_layers,
-            sigmoid=sigmoid,
-            softmax=softmax,
             dropout=dropout,
         )
 

--- a/autrainer/models/tdnn.py
+++ b/autrainer/models/tdnn.py
@@ -14,8 +14,6 @@ class TDNNFFNN(AbstractModel):
         output_dim: int,
         hidden_size: int,
         num_layers: int = 2,
-        sigmoid: bool = False,
-        softmax: bool = False,
         dropout: float = 0.5,
     ) -> None:
         """Time Delay Neural Network with FFNN frontend.
@@ -24,15 +22,11 @@ class TDNNFFNN(AbstractModel):
             output_dim: Output dimension.
             hidden_size: Hidden size.
             num_layers: Number of layers. Defaults to 2.
-            sigmoid: Whether to use sigmoid activation. Defaults to False.
-            softmax: Whether to use softmax activation. Defaults to False.
             dropout: Dropout rate. Defaults to 0.5.
         """
         super().__init__(output_dim)
         self.hidden_size = hidden_size
         self.num_layers = num_layers
-        self.sigmoid = sigmoid
-        self.softmax = softmax
         self.dropout = dropout
         checkpoint_dir = os.path.join(torch.hub.get_dir(), "speechbrain")
         os.makedirs(checkpoint_dir, exist_ok=True)
@@ -50,8 +44,6 @@ class TDNNFFNN(AbstractModel):
             hidden_size=hidden_size,
             output_dim=output_dim,
             num_layers=num_layers,
-            sigmoid=sigmoid,
-            softmax=softmax,
             dropout=dropout,
         )
 

--- a/autrainer/models/w2v2.py
+++ b/autrainer/models/w2v2.py
@@ -43,8 +43,6 @@ class W2V2FFNN(AbstractModel):
         freeze_extractor: bool,
         hidden_size: int,
         num_layers: int = 2,
-        sigmoid: bool = False,
-        softmax: bool = False,
         dropout: float = 0.5,
     ) -> None:
         """Wav2Vec2 model with FFNN frontend adapted for audio classification.
@@ -57,8 +55,6 @@ class W2V2FFNN(AbstractModel):
             freeze_extractor: Whether to freeze the feature extractor.
             hidden_size: Hidden size of the FFNN.
             num_layers: Number of layers of the FFNN. Defaults to 2.
-            sigmoid: Whether to apply sigmoid activation. Defaults to False.
-            softmax: Whether to apply softmax activation. Defaults to False.
             dropout: Dropout rate. Defaults to 0.5.
         """
         super().__init__(output_dim)
@@ -66,8 +62,6 @@ class W2V2FFNN(AbstractModel):
         self.freeze_extractor = freeze_extractor
         self.hidden_size = hidden_size
         self.num_layers = num_layers
-        self.sigmoid = sigmoid
-        self.softmax = softmax
         self.dropout = dropout
         self.backbone = W2V2Backbone(
             model_name=model_name,
@@ -79,8 +73,6 @@ class W2V2FFNN(AbstractModel):
             hidden_size=hidden_size,
             output_dim=output_dim,
             num_layers=num_layers,
-            sigmoid=sigmoid,
-            softmax=softmax,
             dropout=dropout,
         )
 

--- a/autrainer/models/whisper.py
+++ b/autrainer/models/whisper.py
@@ -34,8 +34,6 @@ class WhisperFFNN(AbstractModel):
         model_name: str,
         hidden_size: int,
         num_layers: int = 2,
-        sigmoid: bool = False,
-        softmax: bool = False,
         dropout: float = 0.5,
     ) -> None:
         """Whisper model with FFNN frontend adapted for audio classification.
@@ -47,16 +45,12 @@ class WhisperFFNN(AbstractModel):
             hidden_size: Hidden size of the FFNN.
             output_dim: Output dimension of the FFNN.
             num_layers: Number of layers of the FFNN. Defaults to 2.
-            sigmoid: Whether to apply sigmoid activation. Defaults to False.
-            softmax: Whether to apply softmax activation. Defaults to False.
             dropout: Dropout rate. Defaults to 0.5.
         """
         super().__init__(output_dim)
         self.model_name = model_name
         self.hidden_size = hidden_size
         self.num_layers = num_layers
-        self.sigmoid = sigmoid
-        self.softmax = softmax
         self.dropout = dropout
         self.backbone = WhisperBackbone(model_name=model_name)
         self.frontend = FFNN(
@@ -64,8 +58,6 @@ class WhisperFFNN(AbstractModel):
             hidden_size=hidden_size,
             output_dim=output_dim,
             num_layers=num_layers,
-            sigmoid=sigmoid,
-            softmax=softmax,
             dropout=dropout,
         )
 

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -151,26 +151,6 @@ class TestAudioRNNModel:
         TestAllModels._test_model(model, (1, 16000))
 
 
-class TestFFNN:
-    def test_sigmoid(self) -> None:
-        model = FFNN(
-            output_dim=10,
-            input_size=64,
-            hidden_size=128,
-            sigmoid=True,
-        )
-        TestAllModels._test_model(model, (64,))
-
-    def test_softmax(self) -> None:
-        model = FFNN(
-            output_dim=10,
-            input_size=64,
-            hidden_size=128,
-            softmax=True,
-        )
-        TestAllModels._test_model(model, (64,))
-
-
 class TestLEAFNet:
     @pytest.mark.parametrize("mode", ["interspeech", "speech_brain"])
     def test_mode(self, mode: str) -> None:

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -120,11 +120,6 @@ class TestCnn10Cnn14:
         model = cls(output_dim=10, transfer=link)
         TestAllModels._test_model(model, (1, 128, 64))
 
-    @pytest.mark.parametrize("cls", [Cnn10, Cnn14])
-    def test_sigmoid(self, cls: Type[Union[Cnn10, Cnn14]]) -> None:
-        model = cls(output_dim=10, sigmoid_output=True)
-        TestAllModels._test_model(model, (1, 128, 64))
-
     @pytest.mark.parametrize(
         "cls, expected",
         [(Cnn10, (1, 8, 10)), (Cnn14, (1, 4, 10))],
@@ -136,10 +131,6 @@ class TestCnn10Cnn14:
     ) -> None:
         model = cls(output_dim=10, segmentwise=True)
         TestAllModels._test_model(model, (1, 128, 64), expected=expected)
-
-    def test_sigmoid_predictions(self) -> None:
-        model = Cnn10(output_dim=10, sigmoid_predictions=True)
-        TestAllModels._test_model(model, (1, 128, 64))
 
     def test_invalid_link(self) -> None:
         with pytest.raises(ValueError):

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -97,10 +97,6 @@ class TestASTModel:
         )
         TestAllModels._test_model(model, (1024, 128))
 
-    def test_sigmoid(self) -> None:
-        model = ASTModel(output_dim=10, sigmoid=True)
-        TestAllModels._test_model(model, (1024, 128))
-
 
 class TestCnn10Cnn14:
     @pytest.mark.parametrize(


### PR DESCRIPTION
Closes #40 by removing all Sigmoid and Softmax functions from all models such that the outputs are always raw logits.