### PR TITLE
Add MSP-Podcast dataset

### DIFF
--- a/autrainer-configurations/dataset/MSPPodcast-EmoAct-wav.yaml
+++ b/autrainer-configurations/dataset/MSPPodcast-EmoAct-wav.yaml
@@ -1,0 +1,29 @@
+# Important: should be used with inference_batch_size: 1
+id: MSPPodcast-EmoAct-wav
+_target_: autrainer.datasets.MSPPodcast
+
+path: data/MSPPodcast
+features_subdir: Audios
+index_column: FileName
+target_column: EmoAct
+file_type: wav
+file_handler: autrainer.datasets.utils.AudioFileHandler
+
+criterion: autrainer.criterions.MSELoss
+metrics:
+  - autrainer.metrics.PCC
+  - autrainer.metrics.CCC
+  - autrainer.metrics.MSE
+  - autrainer.metrics.MAE
+tracking_metric: autrainer.metrics.CCC
+
+transform:
+  type: raw
+  base:
+    - autrainer.transforms.Expand:
+        size: 48000
+        axis: -1
+  train:
+    - autrainer.transforms.RandomCrop:
+        size: 48000
+        axis: -1

--- a/autrainer-configurations/dataset/MSPPodcast-EmoAct-wav.yaml
+++ b/autrainer-configurations/dataset/MSPPodcast-EmoAct-wav.yaml
@@ -3,7 +3,6 @@ id: MSPPodcast-EmoAct-wav
 _target_: autrainer.datasets.MSPPodcast
 
 path: data/MSPPodcast
-features_subdir: Audios
 index_column: FileName
 target_column: EmoAct
 file_type: wav

--- a/autrainer-configurations/dataset/MSPPodcast-EmoClass-all-wav.yaml
+++ b/autrainer-configurations/dataset/MSPPodcast-EmoClass-all-wav.yaml
@@ -1,9 +1,7 @@
-# Important: should be used with inference_batch_size: 1
 id: MSPPodcast-EmoClass-all-wav
 _target_: autrainer.datasets.MSPPodcast
 
 path: data/MSPPodcast
-features_subdir: Audios
 index_column: FileName
 target_column: EmoClass
 file_type: wav

--- a/autrainer-configurations/dataset/MSPPodcast-EmoClass-all-wav.yaml
+++ b/autrainer-configurations/dataset/MSPPodcast-EmoClass-all-wav.yaml
@@ -1,0 +1,28 @@
+# Important: should be used with inference_batch_size: 1
+id: MSPPodcast-EmoClass-all-wav
+_target_: autrainer.datasets.MSPPodcast
+
+path: data/MSPPodcast
+features_subdir: Audios
+index_column: FileName
+target_column: EmoClass
+file_type: wav
+file_handler: autrainer.datasets.utils.AudioFileHandler
+
+criterion: autrainer.criterions.BalancedCrossEntropyLoss
+metrics: 
+  - autrainer.metrics.Accuracy
+  - autrainer.metrics.UAR
+  - autrainer.metrics.F1
+tracking_metric: autrainer.metrics.Accuracy
+
+transform:
+  type: raw
+  base:
+    - autrainer.transforms.Expand:
+        size: 48000
+        axis: -1
+  train:
+    - autrainer.transforms.RandomCrop:
+        size: 48000
+        axis: -1

--- a/autrainer-configurations/dataset/MSPPodcast-EmoClass-big4-wav.yaml
+++ b/autrainer-configurations/dataset/MSPPodcast-EmoClass-big4-wav.yaml
@@ -3,7 +3,6 @@ id: MSPPodcast-EmoClass-big4-wav
 _target_: autrainer.datasets.MSPPodcast
 
 path: data/MSPPodcast
-features_subdir: Audios
 index_column: FileName
 target_column: EmoClass
 file_type: wav

--- a/autrainer-configurations/dataset/MSPPodcast-EmoClass-big4-wav.yaml
+++ b/autrainer-configurations/dataset/MSPPodcast-EmoClass-big4-wav.yaml
@@ -1,0 +1,30 @@
+# Important: should be used with inference_batch_size: 1
+id: MSPPodcast-EmoClass-big4-wav
+_target_: autrainer.datasets.MSPPodcast
+
+path: data/MSPPodcast
+features_subdir: Audios
+index_column: FileName
+target_column: EmoClass
+file_type: wav
+file_handler: autrainer.datasets.utils.AudioFileHandler
+
+criterion: autrainer.criterions.BalancedCrossEntropyLoss
+metrics: 
+  - autrainer.metrics.Accuracy
+  - autrainer.metrics.UAR
+  - autrainer.metrics.F1
+tracking_metric: autrainer.metrics.Accuracy
+
+categories: A,H,N,S
+
+transform:
+  type: raw
+  base:
+    - autrainer.transforms.Expand:
+        size: 48000
+        axis: -1
+  train:
+    - autrainer.transforms.RandomCrop:
+        size: 48000
+        axis: -1

--- a/autrainer-configurations/dataset/MSPPodcast-EmoClass-big4-wav.yaml
+++ b/autrainer-configurations/dataset/MSPPodcast-EmoClass-big4-wav.yaml
@@ -15,7 +15,7 @@ metrics:
   - autrainer.metrics.F1
 tracking_metric: autrainer.metrics.Accuracy
 
-categories: A,H,N,S
+categories: [A,H,N,S]
 
 transform:
   type: raw

--- a/autrainer-configurations/dataset/MSPPodcast-EmoDom-wav.yaml
+++ b/autrainer-configurations/dataset/MSPPodcast-EmoDom-wav.yaml
@@ -3,7 +3,6 @@ id: MSPPodcast-EmoDom-wav
 _target_: autrainer.datasets.MSPPodcast
 
 path: data/MSPPodcast
-features_subdir: Audios
 index_column: FileName
 target_column: EmoDom
 file_type: wav

--- a/autrainer-configurations/dataset/MSPPodcast-EmoDom-wav.yaml
+++ b/autrainer-configurations/dataset/MSPPodcast-EmoDom-wav.yaml
@@ -1,0 +1,29 @@
+# Important: should be used with inference_batch_size: 1
+id: MSPPodcast-EmoDom-wav
+_target_: autrainer.datasets.MSPPodcast
+
+path: data/MSPPodcast
+features_subdir: Audios
+index_column: FileName
+target_column: EmoDom
+file_type: wav
+file_handler: autrainer.datasets.utils.AudioFileHandler
+
+criterion: autrainer.criterions.MSELoss
+metrics:
+  - autrainer.metrics.PCC
+  - autrainer.metrics.CCC
+  - autrainer.metrics.MSE
+  - autrainer.metrics.MAE
+tracking_metric: autrainer.metrics.CCC
+
+transform:
+  type: raw
+  base:
+    - autrainer.transforms.Expand:
+        size: 48000
+        axis: -1
+  train:
+    - autrainer.transforms.RandomCrop:
+        size: 48000
+        axis: -1

--- a/autrainer-configurations/dataset/MSPPodcast-EmoVal-wav.yaml
+++ b/autrainer-configurations/dataset/MSPPodcast-EmoVal-wav.yaml
@@ -3,7 +3,6 @@ id: MSPPodcast-EmoVal-wav
 _target_: autrainer.datasets.MSPPodcast
 
 path: data/MSPPodcast
-features_subdir: Audios
 index_column: FileName
 target_column: EmoVal
 file_type: wav

--- a/autrainer-configurations/dataset/MSPPodcast-EmoVal-wav.yaml
+++ b/autrainer-configurations/dataset/MSPPodcast-EmoVal-wav.yaml
@@ -1,0 +1,29 @@
+# Important: should be used with inference_batch_size: 1
+id: MSPPodcast-EmoVal-wav
+_target_: autrainer.datasets.MSPPodcast
+
+path: data/MSPPodcast
+features_subdir: Audios
+index_column: FileName
+target_column: EmoVal
+file_type: wav
+file_handler: autrainer.datasets.utils.AudioFileHandler
+
+criterion: autrainer.criterions.MSELoss
+metrics:
+  - autrainer.metrics.PCC
+  - autrainer.metrics.CCC
+  - autrainer.metrics.MSE
+  - autrainer.metrics.MAE
+tracking_metric: autrainer.metrics.CCC
+
+transform:
+  type: raw
+  base:
+    - autrainer.transforms.Expand:
+        size: 48000
+        axis: -1
+  train:
+    - autrainer.transforms.RandomCrop:
+        size: 48000
+        axis: -1

--- a/autrainer/datasets/__init__.py
+++ b/autrainer/datasets/__init__.py
@@ -11,6 +11,7 @@ from .dcase_2018_t3 import DCASE2018Task3
 from .dcase_2020_t1a import DCASE2020Task1A
 from .edansa2019 import EDANSA2019
 from .emo_db import EmoDB
+from .msppodcast import MSPPodcast
 from .speech_commands import SpeechCommands
 from .toy_dataset import ToyDataset
 
@@ -27,6 +28,7 @@ __all__ = [
     "DCASE2020Task1A",
     "EDANSA2019",
     "EmoDB",
+    "MSPPodcast",
     "SpeechCommands",
     "ToyDataset",
 ]

--- a/autrainer/datasets/msppodcast.py
+++ b/autrainer/datasets/msppodcast.py
@@ -1,0 +1,202 @@
+import os
+from functools import cached_property
+from typing import Dict, List, Optional, Tuple, Union
+
+from omegaconf import DictConfig
+import pandas as pd
+import torch
+
+from autrainer.transforms import SmartCompose
+
+from .abstract_dataset import AbstractDataset
+from .aibo import Standardizer
+from .utils import (
+    AbstractTargetTransform,
+    LabelEncoder,
+    MinMaxScaler,
+)
+
+class MSPPodcast(AbstractDataset):
+    def __init__(
+        self,
+        path: str,
+        features_subdir: str,
+        seed: int,
+        metrics: List[str],
+        tracking_metric: str,
+        index_column: str,
+        target_column: str,
+        file_type:str,
+        file_handler: Union[str, DictConfig, Dict],
+        batch_size: int,
+        inference_batch_size: Optional[int] = None,
+        train_transform: Optional[SmartCompose] = None,
+        dev_transform: Optional[SmartCompose] = None,
+        test_transform: Optional[SmartCompose] = None,
+        stratify: Optional[List[str]] = None,
+        standardize: bool = False,
+        categories: List[str] = None,
+    ) -> None:
+        """MSP-Podcast dataset.
+
+        .. warning::
+            There are multiple versions available for this dataset.
+            We recommend always using the latest one 
+            (v1.11 at the time of writing)
+            but our code is set up to work with all versions
+            (at least up to v1.11).
+        
+        .. note::
+            Note that after v1.7, the dataset features two test sets.
+            We only use ``test1'', as ``test2'' was found to be biased
+            with respect to gender. 
+            See https://doi.org/10.21437/Interspeech.2019-1708.
+
+        .. note::
+            Unlike other datasets which only support classification
+            or regression, MSP-Podcast supports both. This is determined
+            by picking the appropriate target column.
+            ``EmoClass`` corresponds to categorical emotion classification,
+            whereas ``EmoAct``, ``EmoVal``, and ``EmoDom`` to dimensional
+            emotion regression for activation (arousal), valence, and dominance,
+            respectively.            
+
+        Args:
+            path: Root path to the dataset.
+            features_subdir: Subdirectory containing the features.
+            seed: Seed for reproducibility.
+            metrics: List of metrics to calculate.
+            tracking_metric: Metric to track.
+            index_column: Index column of the dataframe.
+            target_column: Target column of the dataframe.
+            file_type: File type of the features.
+            file_handler: File handler to load the data.
+            batch_size: Batch size.
+            inference_batch_size: Inference batch size. If None, defaults to
+                batch_size. Defaults to None.
+            train_transform: Transform to apply to the training set.
+                Defaults to None.
+            dev_transform: Transform to apply to the development set.
+                Defaults to None.
+            test_transform: Transform to apply to the test set.
+                Defaults to None.
+            stratify: Columns to stratify the dataset on. Defaults to None.
+            standardize: Whether to standardize the data. Defaults to False.
+            categories: used to filter out specific emotional categories. 
+                Useful for training on subset of data/classes, such as the classic
+                ["A", "H", "N", "S"] 4-class problem found in literature. 
+                Defaults to None.
+        """
+        # TODO: expand for multitask regression
+        assert target_column in ("EmoClass", "EmoAct", "EmoVal", "EmoDom"), (
+            f"{target_column} not included in target list, please choose one of: "
+            "[EmoClass, EmoAct, EmoVal, EmoDom]"
+        )
+        task = "classification" if target_column == "EmoClass" else "regression"
+        self.categories = categories
+        super().__init__(
+            task=task,
+            path=path,
+            features_subdir=features_subdir,
+            seed=seed,
+            metrics=metrics,
+            tracking_metric=tracking_metric,
+            index_column=index_column,
+            target_column=target_column,
+            file_type=file_type,
+            file_handler=file_handler,
+            batch_size=batch_size,
+            inference_batch_size=inference_batch_size,
+            train_transform=train_transform,
+            dev_transform=dev_transform,
+            test_transform=test_transform,
+            stratify=stratify,
+        )
+        self.standardize = standardize
+        if self.standardize:
+            train_data = torch.cat([x for x, *_ in self.train_dataset])
+            standardizer = Standardizer(
+                mean=train_data.mean(0).tolist(),
+                std=train_data.std(0).tolist(),
+            )
+
+            self.train_transform += standardizer
+            self.dev_transform += standardizer
+            self.test_transform += standardizer
+
+            self.train_dataset = self._init_dataset(
+                self.df_train, self.train_transform
+            )
+
+    @staticmethod
+    def download(path: str) -> None:  # pragma: no cover
+        """
+        Download the MSP-Podcast dataset.
+
+        As this dataset is not publicly-available, please download it manually
+        by contacting Prof. Carlos Busso: 
+        https://ecs.utdallas.edu/research/researchlabs/msp-lab/MSP-Podcast.html
+
+        This function will not do anything.
+
+        For more information on the data, see:
+        https://doi.org/10.1109/TAFFC.2017.2736999
+        """
+        return None
+    
+    def load_dataframes(
+        self,
+    ) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+        """Load the dataframes.
+
+        Overrides base class so there is no need
+        to create separate train/dev/test files.
+
+        Returns:
+            Dataframes for training, development, and testing.
+        """
+        df = pd.read_csv(os.path.join(self.path, "Labels", "labels_consensus.csv"))
+        if self.categories is not None:
+            df = df.loc[df["EmoClass"].isin(self.categories)]
+
+        df_train = df.loc[df["Split_Set"] == "Train"]
+        df_dev = df.loc[df["Split_Set"] == "Development"]
+        df_test = df.loc[df["Split_Set"] == "Test1"]
+        return df_train, df_dev, df_test
+    
+    @cached_property
+    def target_transform(self) -> AbstractTargetTransform:
+        """Get the target transform.
+
+        Determined automatically based on the type of task.
+
+        Returns:
+            Target transform.
+        """
+        if self.task == "classification":
+            return LabelEncoder(
+                self.df_train[self.target_column].unique().tolist()
+            )
+        elif self.task == "regression":
+            return MinMaxScaler(
+                minimum=self.df_train[self.target_column].min(),
+                maximum=self.df_train[self.target_column].max(),
+            )
+        else:
+            raise NotImplementedError(f"{self.task} not supported for MSPPodcast")
+
+    @cached_property
+    def output_dim(self) -> int:
+        """Get the output dimension of the dataset.
+
+        Determined automatically based on the type of task.
+
+        Returns:
+            Number of classes.
+        """
+        if self.task == "classification":
+            return len(self.df_train[self.target_column].unique())
+        elif self.task == "regression":
+            return 1
+        else:
+            raise NotImplementedError(f"{self.task} not supported for MSPPodcast")

--- a/autrainer/datasets/msppodcast.py
+++ b/autrainer/datasets/msppodcast.py
@@ -25,10 +25,8 @@ class MSPPodcast(AbstractDataset):
         target_column: str,
         file_type: str,
         file_handler: Union[str, DictConfig, Dict],
-        batch_size: int,
         index_column: str = "FileName",
         features_subdir: str = None,
-        inference_batch_size: Optional[int] = None,
         train_transform: Optional[SmartCompose] = None,
         dev_transform: Optional[SmartCompose] = None,
         test_transform: Optional[SmartCompose] = None,
@@ -65,13 +63,11 @@ class MSPPodcast(AbstractDataset):
             seed: Seed for reproducibility.
             metrics: List of metrics to calculate.
             tracking_metric: Metric to track.
-            index_column: Index column of the dataframe.
             target_column: Target column of the dataframe.
             file_type: File type of the features.
             file_handler: File handler to load the data.
-            batch_size: Batch size.
-            inference_batch_size: Inference batch size. If None, defaults to
-                batch_size. Defaults to None.
+            index_column: Index column of the dataframe.
+                Defaults to `FileName`, as in the original data.
             train_transform: Transform to apply to the training set.
                 Defaults to None.
             dev_transform: Transform to apply to the development set.
@@ -99,8 +95,6 @@ class MSPPodcast(AbstractDataset):
             target_column=target_column,
             file_type=file_type,
             file_handler=file_handler,
-            batch_size=batch_size,
-            inference_batch_size=inference_batch_size,
             train_transform=train_transform,
             dev_transform=dev_transform,
             test_transform=test_transform,

--- a/autrainer/datasets/msppodcast.py
+++ b/autrainer/datasets/msppodcast.py
@@ -5,30 +5,29 @@ from typing import Dict, List, Optional, Union
 from omegaconf import DictConfig
 import pandas as pd
 
-from autrainer.transforms import SmartCompose
-
-from .abstract_dataset import AbstractDataset
-from .utils import (
+from autrainer.datasets.abstract_dataset import AbstractDataset
+from autrainer.datasets.utils import (
     AbstractTargetTransform,
     LabelEncoder,
     MinMaxScaler,
     MultiTargetMinMaxScaler,
 )
+from autrainer.transforms import SmartCompose
 
 
 class MSPPodcast(AbstractDataset):
     def __init__(
         self,
         path: str,
-        features_subdir: str,
         seed: int,
         metrics: List[str],
         tracking_metric: str,
-        index_column: str,
         target_column: str,
         file_type: str,
         file_handler: Union[str, DictConfig, Dict],
         batch_size: int,
+        index_column: str = "FileName",
+        features_subdir: str = None,
         inference_batch_size: Optional[int] = None,
         train_transform: Optional[SmartCompose] = None,
         dev_transform: Optional[SmartCompose] = None,
@@ -188,6 +187,7 @@ class MSPPodcast(AbstractDataset):
                 )
             else:
                 return MinMaxScaler(
+                    target=self.target_column,
                     minimum=self.df_train[self.target_column].min(),
                     maximum=self.df_train[self.target_column].max(),
                 )

--- a/autrainer/datasets/msppodcast.py
+++ b/autrainer/datasets/msppodcast.py
@@ -48,7 +48,7 @@ class MSPPodcast(AbstractDataset):
         
         .. note::
             Note that after v1.7, the dataset features two test sets.
-            We only use ``test1'', as ``test2'' was found to be biased
+            We only use ``Test1``, as ``Test2`` was found to be biased
             with respect to gender. 
             See https://doi.org/10.21437/Interspeech.2019-1708.
 

--- a/autrainer/datasets/msppodcast.py
+++ b/autrainer/datasets/msppodcast.py
@@ -126,7 +126,7 @@ class MSPPodcast(AbstractDataset):
         return None
 
     @cached_property
-    def _load_df(
+    def _df(
         self,
     ) -> pd.DataFrame:
         """Load the dataframes.
@@ -146,18 +146,21 @@ class MSPPodcast(AbstractDataset):
 
     @cached_property
     def df_train(self):
-        df = self._load_df
-        return df.loc[df["Split_Set"] == "Train"].reset_index(drop=True)
+        return self._df.loc[self._df["Split_Set"] == "Train"].reset_index(
+            drop=True
+        )
 
     @cached_property
     def df_dev(self):
-        df = self._load_df
-        return df.loc[df["Split_Set"] == "Development"].reset_index(drop=True)
+        return self._df.loc[
+            self._df["Split_Set"] == "Development"
+        ].reset_index(drop=True)
 
     @cached_property
     def df_test(self):
-        df = self._load_df
-        return df.loc[df["Split_Set"] == "Test1"].reset_index(drop=True)
+        return self._df.loc[self._df["Split_Set"] == "Test1"].reset_index(
+            drop=True
+        )
 
     @cached_property
     def target_transform(self) -> AbstractTargetTransform:
@@ -185,27 +188,6 @@ class MSPPodcast(AbstractDataset):
                     minimum=self.df_train[self.target_column].min(),
                     maximum=self.df_train[self.target_column].max(),
                 )
-        else:
-            raise NotImplementedError(
-                f"{self.task} not supported for MSPPodcast"
-            )
-
-    @cached_property
-    def output_dim(self) -> int:
-        """Get the output dimension of the dataset.
-
-        Determined automatically based on the type of task.
-
-        Returns:
-            Number of classes.
-        """
-        if self.task == "classification":
-            return len(self.df_train[self.target_column].unique())
-        elif self.task == "regression":
-            if isinstance(self.target_column, list):
-                return len(self.target_column)
-            else:
-                return 1
         else:
             raise NotImplementedError(
                 f"{self.task} not supported for MSPPodcast"

--- a/autrainer/datasets/msppodcast.py
+++ b/autrainer/datasets/msppodcast.py
@@ -1,20 +1,20 @@
-import os
 from functools import cached_property
-from typing import Dict, List, Optional, Tuple, Union
+import os
+from typing import Dict, List, Optional, Union
 
 from omegaconf import DictConfig
 import pandas as pd
-import torch
 
 from autrainer.transforms import SmartCompose
 
 from .abstract_dataset import AbstractDataset
-from .aibo import Standardizer
 from .utils import (
     AbstractTargetTransform,
     LabelEncoder,
     MinMaxScaler,
+    MultiTargetMinMaxScaler,
 )
+
 
 class MSPPodcast(AbstractDataset):
     def __init__(
@@ -26,7 +26,7 @@ class MSPPodcast(AbstractDataset):
         tracking_metric: str,
         index_column: str,
         target_column: str,
-        file_type:str,
+        file_type: str,
         file_handler: Union[str, DictConfig, Dict],
         batch_size: int,
         inference_batch_size: Optional[int] = None,
@@ -34,22 +34,21 @@ class MSPPodcast(AbstractDataset):
         dev_transform: Optional[SmartCompose] = None,
         test_transform: Optional[SmartCompose] = None,
         stratify: Optional[List[str]] = None,
-        standardize: bool = False,
         categories: List[str] = None,
     ) -> None:
         """MSP-Podcast dataset.
 
         .. warning::
             There are multiple versions available for this dataset.
-            We recommend always using the latest one 
+            We recommend always using the latest one
             (v1.11 at the time of writing)
             but our code is set up to work with all versions
             (at least up to v1.11).
-        
+
         .. note::
             Note that after v1.7, the dataset features two test sets.
             We only use ``Test1``, as ``Test2`` was found to be biased
-            with respect to gender. 
+            with respect to gender.
             See https://doi.org/10.21437/Interspeech.2019-1708.
 
         .. note::
@@ -59,7 +58,7 @@ class MSPPodcast(AbstractDataset):
             ``EmoClass`` corresponds to categorical emotion classification,
             whereas ``EmoAct``, ``EmoVal``, and ``EmoDom`` to dimensional
             emotion regression for activation (arousal), valence, and dominance,
-            respectively.            
+            respectively.
 
         Args:
             path: Root path to the dataset.
@@ -81,18 +80,14 @@ class MSPPodcast(AbstractDataset):
             test_transform: Transform to apply to the test set.
                 Defaults to None.
             stratify: Columns to stratify the dataset on. Defaults to None.
-            standardize: Whether to standardize the data. Defaults to False.
-            categories: used to filter out specific emotional categories. 
+            categories: used to filter out specific emotional categories.
                 Useful for training on subset of data/classes, such as the classic
-                ["A", "H", "N", "S"] 4-class problem found in literature. 
+                ["A", "H", "N", "S"] 4-class problem found in literature.
                 Defaults to None.
         """
-        # TODO: expand for multitask regression
-        assert target_column in ("EmoClass", "EmoAct", "EmoVal", "EmoDom"), (
-            f"{target_column} not included in target list, please choose one of: "
-            "[EmoClass, EmoAct, EmoVal, EmoDom]"
+        task = (
+            "classification" if target_column == "EmoClass" else "regression"
         )
-        task = "classification" if target_column == "EmoClass" else "regression"
         self.categories = categories
         super().__init__(
             task=task,
@@ -112,21 +107,14 @@ class MSPPodcast(AbstractDataset):
             test_transform=test_transform,
             stratify=stratify,
         )
-        self.standardize = standardize
-        if self.standardize:
-            train_data = torch.cat([x for x, *_ in self.train_dataset])
-            standardizer = Standardizer(
-                mean=train_data.mean(0).tolist(),
-                std=train_data.std(0).tolist(),
-            )
 
-            self.train_transform += standardizer
-            self.dev_transform += standardizer
-            self.test_transform += standardizer
+    @property
+    def audio_subdir(self) -> str:
+        """Subfolder containing audio data.
 
-            self.train_dataset = self._init_dataset(
-                self.df_train, self.train_transform
-            )
+        Defaults to `Audios` for MSP-Podcast.
+        """
+        return "Audios"
 
     @staticmethod
     def download(path: str) -> None:  # pragma: no cover
@@ -134,7 +122,7 @@ class MSPPodcast(AbstractDataset):
         Download the MSP-Podcast dataset.
 
         As this dataset is not publicly-available, please download it manually
-        by contacting Prof. Carlos Busso: 
+        by contacting Prof. Carlos Busso:
         https://ecs.utdallas.edu/research/researchlabs/msp-lab/MSP-Podcast.html
 
         This function will not do anything.
@@ -143,10 +131,11 @@ class MSPPodcast(AbstractDataset):
         https://doi.org/10.1109/TAFFC.2017.2736999
         """
         return None
-    
-    def load_dataframes(
+
+    @cached_property
+    def _load_df(
         self,
-    ) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    ) -> pd.DataFrame:
         """Load the dataframes.
 
         Overrides base class so there is no need
@@ -155,15 +144,28 @@ class MSPPodcast(AbstractDataset):
         Returns:
             Dataframes for training, development, and testing.
         """
-        df = pd.read_csv(os.path.join(self.path, "Labels", "labels_consensus.csv"))
+        df = pd.read_csv(
+            os.path.join(self.path, "Labels", "labels_consensus.csv")
+        )
         if self.categories is not None:
             df = df.loc[df["EmoClass"].isin(self.categories)]
+        return df.reset_index(drop=True)
 
-        df_train = df.loc[df["Split_Set"] == "Train"]
-        df_dev = df.loc[df["Split_Set"] == "Development"]
-        df_test = df.loc[df["Split_Set"] == "Test1"]
-        return df_train, df_dev, df_test
-    
+    @cached_property
+    def df_train(self):
+        df = self._load_df
+        return df.loc[df["Split_Set"] == "Train"].reset_index(drop=True)
+
+    @cached_property
+    def df_dev(self):
+        df = self._load_df
+        return df.loc[df["Split_Set"] == "Development"].reset_index(drop=True)
+
+    @cached_property
+    def df_test(self):
+        df = self._load_df
+        return df.loc[df["Split_Set"] == "Test1"].reset_index(drop=True)
+
     @cached_property
     def target_transform(self) -> AbstractTargetTransform:
         """Get the target transform.
@@ -178,12 +180,21 @@ class MSPPodcast(AbstractDataset):
                 self.df_train[self.target_column].unique().tolist()
             )
         elif self.task == "regression":
-            return MinMaxScaler(
-                minimum=self.df_train[self.target_column].min(),
-                maximum=self.df_train[self.target_column].max(),
-            )
+            if isinstance(self.target_column, list):
+                return MultiTargetMinMaxScaler(
+                    target=self.target_column,
+                    minimum=self.df_train[self.target_column].min().to_list(),
+                    maximum=self.df_train[self.target_column].max().to_list(),
+                )
+            else:
+                return MinMaxScaler(
+                    minimum=self.df_train[self.target_column].min(),
+                    maximum=self.df_train[self.target_column].max(),
+                )
         else:
-            raise NotImplementedError(f"{self.task} not supported for MSPPodcast")
+            raise NotImplementedError(
+                f"{self.task} not supported for MSPPodcast"
+            )
 
     @cached_property
     def output_dim(self) -> int:
@@ -197,6 +208,11 @@ class MSPPodcast(AbstractDataset):
         if self.task == "classification":
             return len(self.df_train[self.target_column].unique())
         elif self.task == "regression":
-            return 1
+            if isinstance(self.target_column, list):
+                return len(self.target_column)
+            else:
+                return 1
         else:
-            raise NotImplementedError(f"{self.task} not supported for MSPPodcast")
+            raise NotImplementedError(
+                f"{self.task} not supported for MSPPodcast"
+            )

--- a/docs/source/modules/datasets.rst
+++ b/docs/source/modules/datasets.rst
@@ -189,6 +189,17 @@ We provide a number of different audio-specific datasets.
          :subdir: dataset
          :configs: EmoDB
 
+
+.. autoclass:: autrainer.datasets.MSPPodcast
+   :members:
+
+   .. dropdown:: Default Configurations
+
+      .. configurations::
+         :subdir: dataset
+         :configs: MSPPodcast
+
+
 .. autoclass:: autrainer.datasets.SpeechCommands
    :members:
 


### PR DESCRIPTION
Adds MSP-Podcast dataset. As I haven't done that in a while, it would be fantastic if you can have a look @ramppdev 

Additionally, I remove a stray print in `AIBO`. That was only there for debugging.

---
P.S. I am also wondering what's the preferred way for debugging a dataset when developing? For now, I used a `python` script:

```python
from autrainer.datasets.msppodcast import MSPPodcast


data = MSPPodcast(
    path="",
    index_column="FileName",
    target_column="EmoValf",
    file_type="wav",
    file_handler="autrainer.datasets.utils.AudioFileHandler",
    features_subdir="Audios",
    metrics=["autrainer.metrics.Accuracy"],
    tracking_metric="autrainer.metrics.Accuracy",
    batch_size=1,
    seed=42,
    categories=["A", "H", "N", "S"]
    # train_transform=autrainer.transforms.RandomCrop
)
train_loader = data.train_loader
print(data.target_transform)

print(next(iter(train_loader)))
```

But is there some command that we can use to quickly test the dataset? Or is it something we could plausibly add as another CLI option, e.g. `autrainer debug dataset`, which would then output some basic checks?