### PR TITLE
Add Target Transform Length

### DIFF
--- a/autrainer/datasets/abstract_dataset.py
+++ b/autrainer/datasets/abstract_dataset.py
@@ -134,14 +134,14 @@ class AbstractDataset(ABC):
             Target transform.
         """
 
-    @property
-    @abstractmethod
+    @cached_property
     def output_dim(self) -> int:
         """Get the output dimension of the dataset.
 
         Returns:
             Output dimension.
         """
+        return len(self.target_transform)
 
     @staticmethod
     def _init_metric(metric: Union[str, DictConfig, Dict]) -> AbstractMetric:
@@ -359,15 +359,6 @@ class BaseClassificationDataset(AbstractDataset):
             self.df_train[self.target_column].unique().tolist()
         )
 
-    @cached_property
-    def output_dim(self) -> int:
-        """Get the output dimension of the dataset.
-
-        Returns:
-            Number of classes.
-        """
-        return len(self.df_train[self.target_column].unique())
-
     @staticmethod
     def _assert_dev_split(dev_split: float) -> None:
         if not 0 <= dev_split < 1:
@@ -471,15 +462,6 @@ class BaseMLClassificationDataset(AbstractDataset):
     def target_transform(self) -> MultiLabelEncoder:
         return MultiLabelEncoder(self.threshold, self.target_column)
 
-    @cached_property
-    def output_dim(self) -> int:
-        """Get the output dimension of the dataset.
-
-        Returns:
-            Number of classes.
-        """
-        return len(self.target_column)
-
 
 class BaseRegressionDataset(AbstractDataset):
     def __init__(
@@ -549,12 +531,3 @@ class BaseRegressionDataset(AbstractDataset):
             minimum=self.df_train[self.target_column].min(),
             maximum=self.df_train[self.target_column].max(),
         )
-
-    @cached_property
-    def output_dim(self) -> int:
-        """Get the output dimension of the dataset.
-
-        Returns:
-            Always 1 for regression tasks.
-        """
-        return 1

--- a/autrainer/datasets/toy_dataset.py
+++ b/autrainer/datasets/toy_dataset.py
@@ -240,9 +240,3 @@ class ToyDataset(AbstractDataset):
             minimum=self.df_train[self.target_column].min(),
             maximum=self.df_train[self.target_column].max(),
         )
-
-    @cached_property
-    def output_dim(self) -> int:
-        if self.task in ["ml-classification", "classification"]:
-            return self.num_targets
-        return 1

--- a/autrainer/datasets/utils/target_transforms/abstract_target_transform.py
+++ b/autrainer/datasets/utils/target_transforms/abstract_target_transform.py
@@ -20,6 +20,14 @@ class AbstractTargetTransform(ABC, audobject.Object):
         return self.encode(x)
 
     @abstractmethod
+    def __len__(self) -> int:
+        """Get the number of unique targets or labels.
+
+        Returns:
+            Number of unique targets or labels.
+        """
+
+    @abstractmethod
     def encode(self, x: Any) -> Any:
         """Encode a target or label.
 

--- a/autrainer/datasets/utils/target_transforms/label_encoder.py
+++ b/autrainer/datasets/utils/target_transforms/label_encoder.py
@@ -19,6 +19,14 @@ class LabelEncoder(AbstractTargetTransform):
         }
         self.map = {label: code for code, label in zip(codes, self.labels)}
 
+    def __len__(self) -> int:
+        """Get the number of unique target labels.
+
+        Returns:
+            Number of unique target labels.
+        """
+        return len(self.labels)
+
     def encode(self, x: str) -> int:
         """Encode a target label by mapping it to an integer.
 

--- a/autrainer/datasets/utils/target_transforms/min_max_scaler.py
+++ b/autrainer/datasets/utils/target_transforms/min_max_scaler.py
@@ -25,6 +25,14 @@ class MinMaxScaler(AbstractTargetTransform):
         self.minimum = float(minimum)
         self.maximum = float(maximum)
 
+    def __len__(self) -> int:
+        """Get the number of unique targets.
+
+        Returns:
+            Number of unique targets.
+        """
+        return 1
+
     def encode(self, x: float) -> float:
         """Encode a target value by scaling it between the minimum and maximum.
 

--- a/autrainer/datasets/utils/target_transforms/multi_label_encoder.py
+++ b/autrainer/datasets/utils/target_transforms/multi_label_encoder.py
@@ -24,6 +24,14 @@ class MultiLabelEncoder(AbstractTargetTransform):
         self.threshold = threshold
         self.labels = labels
 
+    def __len__(self) -> int:
+        """Get the number of unique target labels.
+
+        Returns:
+            Number of unique target labels.
+        """
+        return len(self.labels)
+
     def encode(self, x: Union[List[int], List[str]]) -> torch.Tensor:
         """Encode a list of target labels by creating a binary tensor where
         each element is 1 if the label is in the list of target labels and 0

--- a/tests/test_dataset_utils.py
+++ b/tests/test_dataset_utils.py
@@ -76,6 +76,10 @@ def _all_close_dict(a: dict, b: dict) -> bool:
 
 
 class TestMinMaxScaler:
+    def test_len(self) -> None:
+        scaler = MinMaxScaler("target", 0, 1)
+        assert len(scaler) == 1, "Should have a single target."
+
     @pytest.mark.parametrize("minimum, maximum", [(1, 0), (0, 0), (1, 1)])
     def test_invalid_min_max(self, minimum: float, maximum: float) -> None:
         with pytest.raises(ValueError):
@@ -121,6 +125,10 @@ class TestMinMaxScaler:
 
 class TestMultiLabelEncoder:
     labels = ["fizz", "buzz", "jazz"]
+
+    def test_len(self) -> None:
+        encoder = MultiLabelEncoder(0.5, self.labels)
+        assert len(encoder) == 3, "Should have three labels."
 
     @pytest.mark.parametrize("threshold", [-1, -0.01, 1.1, 2])
     def test_invalid_threshold(self, threshold: float) -> None:
@@ -178,6 +186,10 @@ class TestMultiLabelEncoder:
 
 class TestLabelEncoder:
     labels = ["fizz", "buzz", "jazz"]
+
+    def test_len(self) -> None:
+        encoder = LabelEncoder(self.labels)
+        assert len(encoder) == 3, "Should have three labels."
 
     @pytest.mark.parametrize("label", ["jazz", "buzz", "fizz"])
     def test_encode_decode(self, label: str) -> None:

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -450,7 +450,7 @@ class TestToyDataset(BaseIndividualTempDir):
     def _mock_toy_dataset_kwargs(self) -> dict:
         return {
             "task": "classification",
-            "size": 10,
+            "size": 100,
             "num_targets": 10,
             "feature_shape": (101, 64),
             "dev_split": 0.2,
@@ -497,9 +497,9 @@ class TestToyDataset(BaseIndividualTempDir):
         data: AbstractDataset,
         y_shape: Tuple[int, ...],
     ) -> None:
-        assert len(data.train_dataset) == 6, "Should be 6."
-        assert len(data.dev_dataset) == 2, "Should be 2."
-        assert len(data.test_dataset) == 2, "Should be 2."
+        assert len(data.train_dataset) == 60, "Should be 60."
+        assert len(data.dev_dataset) == 20, "Should be 20."
+        assert len(data.test_dataset) == 20, "Should be 20."
 
         x, y, _ = next(iter(data.train_loader))
         assert x.shape == (4, 101, 64), "Should be (4, 101, 64)."


### PR DESCRIPTION
Closes #49 by implementing `__len__` for all target transforms.
This also allows to push the `output_dim` property back to the abstract dataset class and simplifies the creation of custom datasets.