### PR TITLE
Add Multi-Target Regression Task

### DIFF
--- a/autrainer-configurations/dataset/ToyAudio-MTR.yaml
+++ b/autrainer-configurations/dataset/ToyAudio-MTR.yaml
@@ -1,0 +1,20 @@
+id: ToyAudio-MTR
+_target_: autrainer.datasets.ToyDataset
+
+task: mt-regression
+size: 1000
+num_targets: 10
+feature_shape: [1, 48000]
+dev_split: 0.2
+test_split: 0.2
+
+criterion: autrainer.criterions.MSELoss
+metrics:
+  - autrainer.metrics.PCC
+  - autrainer.metrics.CCC
+  - autrainer.metrics.MSE
+  - autrainer.metrics.MAE
+tracking_metric: autrainer.metrics.PCC
+
+transform:
+  type: raw

--- a/autrainer-configurations/dataset/ToyImage-MTR.yaml
+++ b/autrainer-configurations/dataset/ToyImage-MTR.yaml
@@ -1,0 +1,26 @@
+id: ToyImage-MTR
+_target_: autrainer.datasets.ToyDataset
+
+task: mt-regression
+size: 1000
+num_targets: 10
+feature_shape: [3, 64, 64]
+dev_split: 0.2
+test_split: 0.2
+dtype: uint8
+
+criterion: autrainer.criterions.MSELoss
+metrics:
+  - autrainer.metrics.PCC
+  - autrainer.metrics.CCC
+  - autrainer.metrics.MSE
+  - autrainer.metrics.MAE
+tracking_metric: autrainer.metrics.PCC
+
+transform:
+  type: image
+  base:
+    - autrainer.transforms.ScaleRange
+    - autrainer.transforms.Normalize:
+        mean: [0.485, 0.456, 0.406]
+        std: [0.229, 0.224, 0.225]

--- a/autrainer-configurations/dataset/ToyTabular-MTR.yaml
+++ b/autrainer-configurations/dataset/ToyTabular-MTR.yaml
@@ -1,0 +1,20 @@
+id: ToyTabular-MTR
+_target_: autrainer.datasets.ToyDataset
+
+task: mt-regression
+size: 1000
+num_targets: 10
+feature_shape: 64
+dev_split: 0.2
+test_split: 0.2
+
+criterion: autrainer.criterions.MSELoss
+metrics:
+  - autrainer.metrics.PCC
+  - autrainer.metrics.CCC
+  - autrainer.metrics.MSE
+  - autrainer.metrics.MAE
+tracking_metric: autrainer.metrics.PCC
+
+transform:
+  type: tabular

--- a/autrainer/core/constants/training_constants.py
+++ b/autrainer/core/constants/training_constants.py
@@ -7,13 +7,18 @@ class TrainingConstants(AbstractConstants):
     """Singleton for managing the training configurations of `autrainer`."""
 
     _name = "TrainingConstants"
-    _tasks = ["classification", "regression", "ml-classification"]
+    _tasks = [
+        "classification",
+        "ml-classification",
+        "regression",
+        "mt-regression",
+    ]
 
     @property
     def TASKS(self) -> List[str]:
         """Get the supported training tasks.
-        Defaults to :attr:`["classification", "regression",
-        "ml-classification"]`.
+        Defaults to :attr:`["classification", "ml-classification",
+        "regression", "mt-regression"]`.
 
         Returns:
             Supported training tasks.

--- a/autrainer/datasets/__init__.py
+++ b/autrainer/datasets/__init__.py
@@ -2,6 +2,7 @@ from .abstract_dataset import (
     AbstractDataset,
     BaseClassificationDataset,
     BaseMLClassificationDataset,
+    BaseMTRegressionDataset,
     BaseRegressionDataset,
 )
 from .aibo import AIBO
@@ -18,6 +19,7 @@ __all__ = [
     "AbstractDataset",
     "BaseClassificationDataset",
     "BaseMLClassificationDataset",
+    "BaseMTRegressionDataset",
     "BaseRegressionDataset",
     "AIBO",
     "DCASE2016Task1",

--- a/autrainer/datasets/utils/__init__.py
+++ b/autrainer/datasets/utils/__init__.py
@@ -11,20 +11,22 @@ from .target_transforms import (
     LabelEncoder,
     MinMaxScaler,
     MultiLabelEncoder,
+    MultiTargetMinMaxScaler,
 )
 from .zip_download_manager import ZipDownloadManager
 
 
 __all__ = [
     "AbstractFileHandler",
+    "AbstractTargetTransform",
     "AudioFileHandler",
+    "DatasetWrapper",
     "IdentityFileHandler",
     "ImageFileHandler",
-    "NumpyFileHandler",
-    "AbstractTargetTransform",
     "LabelEncoder",
     "MinMaxScaler",
     "MultiLabelEncoder",
-    "DatasetWrapper",
+    "MultiTargetMinMaxScaler",
+    "NumpyFileHandler",
     "ZipDownloadManager",
 ]

--- a/autrainer/datasets/utils/target_transforms/__init__.py
+++ b/autrainer/datasets/utils/target_transforms/__init__.py
@@ -2,6 +2,7 @@ from .abstract_target_transform import AbstractTargetTransform
 from .label_encoder import LabelEncoder
 from .min_max_scaler import MinMaxScaler
 from .multi_label_encoder import MultiLabelEncoder
+from .multi_target_min_max_scaler import MultiTargetMinMaxScaler
 
 
 __all__ = [
@@ -9,4 +10,5 @@ __all__ = [
     "LabelEncoder",
     "MinMaxScaler",
     "MultiLabelEncoder",
+    "MultiTargetMinMaxScaler",
 ]

--- a/autrainer/datasets/utils/target_transforms/multi_target_min_max_scaler.py
+++ b/autrainer/datasets/utils/target_transforms/multi_target_min_max_scaler.py
@@ -1,0 +1,125 @@
+from typing import Dict, List
+
+import torch
+
+from .abstract_target_transform import AbstractTargetTransform
+
+
+class MultiTargetMinMaxScaler(AbstractTargetTransform):
+    def __init__(
+        self,
+        target: List[str],
+        minimum: List[float],
+        maximum: List[float],
+    ) -> None:
+        """Minimum-Maximum Scaler for multi-target regression.
+
+        Args:
+            target: Names of the targets.
+            minimum: Minimum values of all target values.
+            maximum: Maximum values of all target values.
+
+        Raises:
+            ValueError: If minimum is not less than maximum.
+        """
+        for m, M in zip(minimum, maximum):
+            if not m < M:
+                raise ValueError(
+                    f"Minimum '{m}' must be less than maximum '{M}'."
+                )
+        self.target = target
+        self.minimum = [float(m) for m in minimum]
+        self._m = torch.Tensor(self.minimum)
+        self.maximum = [float(M) for M in maximum]
+        self._M = torch.Tensor(self.maximum)
+
+    def __len__(self) -> int:
+        """Get the number of unique targets.
+
+        Returns:
+            Number of unique targets.
+        """
+        return len(self.target)
+
+    def encode(self, x: List[float]) -> torch.Tensor:
+        """Encode a target value by scaling it between the minimum and maximum.
+
+        Args:
+            x: Target value.
+
+        Returns:
+            Scaled target value.
+        """
+        return (torch.Tensor(x) - self._m) / (self._M - self._m)
+
+    def decode(self, x: List[float]) -> List[float]:
+        """Decode a target value by reversing the scaling between the minimum
+        and maximum. Inverse operation of encode.
+
+        Args:
+            x: Scaled target value.
+
+        Returns:
+            Unscaled target value.
+        """
+        return (torch.Tensor(x) * (self._M - self._m) + self._m).tolist()
+
+    def probabilities_training(self, x: torch.Tensor) -> torch.Tensor:
+        """Get the encoded probabilities from a batch of model outputs
+        during training by applying the sigmoid function.
+
+        Args:
+            x: Batch of model outputs.
+
+        Returns:
+            Encoded probabilities.
+        """
+        return torch.sigmoid(x)
+
+    def probabilities_inference(self, x: torch.Tensor) -> torch.Tensor:
+        """Get the encoded probabilities from a batch of model outputs by
+        applying the sigmoid function.
+
+        Args:
+            x: Batch of model outputs.
+
+        Returns:
+            Encoded probabilities.
+        """
+        return torch.sigmoid(x)
+
+    def predict_inference(self, x: torch.Tensor) -> List[List[float]]:
+        """Get the encoded predictions from a batch of model output
+        probabilities by returning the raw values.
+
+        Args:
+            x: Batch of model output probabilities.
+
+        Returns:
+            Encoded predictions.
+        """
+        return x.tolist()
+
+    def majority_vote(self, x: List[List[float]]) -> List[float]:
+        """Get the majority vote from a list of target values by averaging
+        the predictions.
+
+        Args:
+            x: List of target values.
+
+        Returns:
+            Average target value.
+        """
+        return [sum(item) / len(item) for item in zip(*x)]
+
+    def probabilities_to_dict(self, x: torch.Tensor) -> Dict[str, float]:
+        """Convert a tensor of probabilities to a dictionary of targets and
+        their probabilities.
+
+        Args:
+            x: Tensor of probabilities.
+
+        Returns:
+            Dictionary of targets and their probabilities.
+        """
+        return {label: prob.item() for label, prob in zip(self.target, x)}

--- a/autrainer/metrics/regression.py
+++ b/autrainer/metrics/regression.py
@@ -1,31 +1,86 @@
+from typing import Callable
+
 import audmetric
+import numpy as np
 
 from .abstract_metric import BaseAscendingMetric, BaseDescendingMetric
 
 
+def _mean_metric(
+    y_true: np.ndarray,
+    y_pred: np.ndarray,
+    metric_fn: Callable,
+    **kwargs,
+) -> float:
+    """Calculate the mean of a metric for each target if multi-target arrays
+    are given. If single-target arrays are given, the metric is calculated
+    directly.
+
+    Args:
+        y_true: Ground truth values.
+        y_pred: Predicted values.
+        metric_fn: Metric function.
+
+    Returns:
+        Mean of the metric for each target.
+    """
+    y_true = np.array(y_true)
+    y_pred = np.array(y_pred)
+    if y_true.ndim == 1:
+        return metric_fn(y_true, y_pred, **kwargs)
+    m = np.empty(y_true.shape[1])
+    for i in range(y_true.shape[1]):
+        m[i] = metric_fn(y_true[:, i], y_pred[:, i], **kwargs)
+    return np.mean(m)
+
+
 class MSE(BaseDescendingMetric):
     def __init__(self):
-        """Mean squared error metric using `audmetric.mean_squared_error`."""
-        super().__init__(name="mse", fn=audmetric.mean_squared_error)
+        """Mean squared error metric using `audmetric.mean_squared_error`
+        for (multi-target) regression. The metric is calculated for each
+        target separately and the mean is returned.
+        """
+        super().__init__(
+            name="mse",
+            fn=_mean_metric,
+            metric_fn=audmetric.mean_squared_error,
+        )
 
 
 class MAE(BaseDescendingMetric):
     def __init__(self):
-        """Mean absolute error metric using `audmetric.mean_absolute_error`."""
-        super().__init__(name="mae", fn=audmetric.mean_absolute_error)
+        """Mean absolute error metric using `audmetric.mean_absolute_error`
+        for (multi-target) regression. The metric is calculated for each
+        target separately and the mean is returned.
+        """
+        super().__init__(
+            name="mae",
+            fn=_mean_metric,
+            metric_fn=audmetric.mean_absolute_error,
+        )
 
 
 class PCC(BaseAscendingMetric):
     def __init__(self):
         """Pearson correlation coefficient metric using
-        `audmetric.pearson_cc`.
+        `audmetric.pearson_cc` for (multi-target) regression. The metric is
+        calculated for each target separately and the mean is returned.
         """
-        super().__init__(name="pcc", fn=audmetric.pearson_cc)
+        super().__init__(
+            name="pcc",
+            fn=_mean_metric,
+            metric_fn=audmetric.pearson_cc,
+        )
 
 
 class CCC(BaseAscendingMetric):
     def __init__(self):
         """Concordance correlation coefficient metric using
-        `audmetric.concordance_cc`.
+        `audmetric.concordance_cc` for (multi-target) regression. The metric is
+        calculated for each target separately and the mean is returned.
         """
-        super().__init__(name="ccc", fn=audmetric.concordance_cc)
+        super().__init__(
+            name="ccc",
+            fn=_mean_metric,
+            metric_fn=audmetric.concordance_cc,
+        )

--- a/docs/source/modules/datasets.rst
+++ b/docs/source/modules/datasets.rst
@@ -96,6 +96,9 @@ Base datasets that can be used for training without the need for creating custom
 .. autoclass:: autrainer.datasets.BaseRegressionDataset
    :members:
 
+.. autoclass:: autrainer.datasets.BaseMTRegressionDataset
+   :members:
+
 
 Toy Datasets
 ------------------
@@ -106,7 +109,8 @@ A toy dataset for testing purposes.
 
    To easily test implementations, multiple toy dataset configurations across modalities and tasks are provided.
    We offer :attr:`ToyAudio-...` for audio, :attr:`ToyImage-...` for image, and :attr:`ToyTabular-...` for tabular data, respectively.
-   For each dataset, we provide a task :attr:`...-R` for regression, :attr:`...-C` for classification and :attr:`...-MLC` for multi-label classification.
+   For each dataset, we provide a task :attr:`...-R` for regression, :attr:`...-C` for classification, :attr:`...-MLC` for multi-label classification,
+   and :attr:`...-MTR` for multi-target regression.
 
 .. autoclass:: autrainer.datasets.ToyDataset
 

--- a/docs/source/modules/metrics.rst
+++ b/docs/source/modules/metrics.rst
@@ -43,16 +43,6 @@ Classification Metrics
 
 .. autoclass:: autrainer.metrics.F1
 
-Regression Metrics
--------------------
-
-.. autoclass:: autrainer.metrics.CCC
-
-.. autoclass:: autrainer.metrics.MAE
-
-.. autoclass:: autrainer.metrics.MSE
-
-.. autoclass:: autrainer.metrics.PCC
 
 Multi-label Classification Metrics
 ----------------------------------
@@ -64,3 +54,15 @@ Multi-label Classification Metrics
 .. autoclass:: autrainer.metrics.MLF1Micro
 
 .. autoclass:: autrainer.metrics.MLF1Weighted
+
+
+(Multi-target) Regression Metrics
+---------------------------------
+
+.. autoclass:: autrainer.metrics.CCC
+
+.. autoclass:: autrainer.metrics.MAE
+
+.. autoclass:: autrainer.metrics.MSE
+
+.. autoclass:: autrainer.metrics.PCC

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -533,3 +533,12 @@ class TestToyDataset(BaseIndividualTempDir):
         data = ToyDataset(**kwargs)
         self._test_data_shapes(data, (4,))
         assert data.output_dim == 1, "Should be 1."
+
+    def test_mtr(self) -> None:
+        kwargs = self._mock_toy_dataset_kwargs()
+        kwargs["task"] = "mt-regression"
+        kwargs["metrics"] = ["autrainer.metrics.MSE"]
+        kwargs["tracking_metric"] = "autrainer.metrics.MSE"
+        data = ToyDataset(**kwargs)
+        self._test_data_shapes(data, (4, 10))
+        assert data.output_dim == 10, "Should be 10."

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -20,10 +20,12 @@ class TestCLIIntegration(BaseIndividualTempDir):
             ("ToyTabular-C", "ToyFFNN", "epoch", 2, True),
             ("ToyTabular-R", "ToyFFNN", "epoch", 1, False),
             ("ToyTabular-MLC", "ToyFFNN", "epoch", 1, False),
+            ("ToyTabular-MTR", "ToyFFNN", "epoch", 1, False),
             ("ToyTabular-C", "ToyFFNN", "step", 100, False),
             ("ToyTabular-C", "ToyFFNN", "step", 200, True),
             ("ToyTabular-R", "ToyFFNN", "step", 100, False),
             ("ToyTabular-MLC", "ToyFFNN", "step", 100, False),
+            ("ToyTabular-MTR", "ToyFFNN", "step", 100, False),
         ],
     )
     def test_train_postprocess(


### PR DESCRIPTION
Closes #48 by adding multi-target regression:
- added new `MultiTargetMinMaxScaler` which applies the `MinMaxScaler` for each target column separately
- added new base dataset
- extended `ToyDataset` to multi-target regression (including configurations)
- extended regression metrics to handle multiple targets by calculating the metric for each target and averaging