### PR TITLE
Update dataset interface

### DIFF
--- a/autrainer/core/scripts/preprocess_script.py
+++ b/autrainer/core/scripts/preprocess_script.py
@@ -145,8 +145,6 @@ class PreprocessScript(AbstractPreprocessScript):
             features_subdir = dataset["features_subdir"]
             dataset["features_subdir"] = None
             data = autrainer.instantiate(dataset)
-            if features_path is None:
-                features_path = data.path
             # manually disable dataset transforms
             data.train_transform = None
             data.dev_transform = None

--- a/autrainer/core/scripts/preprocess_script.py
+++ b/autrainer/core/scripts/preprocess_script.py
@@ -160,7 +160,7 @@ class PreprocessScript(AbstractPreprocessScript):
                     dataset=d,
                     shuffle=False,
                     num_workers=self.num_workers,
-                    batch_size=1,  # TODO: can we do it batched?
+                    batch_size=1,
                 )
                 for data in tqdm.tqdm(
                     loader,

--- a/autrainer/core/scripts/preprocess_script.py
+++ b/autrainer/core/scripts/preprocess_script.py
@@ -144,7 +144,6 @@ class PreprocessScript(AbstractPreprocessScript):
             data.train_transform = None
             data.dev_transform = None
             data.test_transform = None
-            os.makedirs(data.features_subdir, exist_ok=True)
 
             pipeline = SmartCompose(
                 [

--- a/autrainer/core/scripts/preprocess_script.py
+++ b/autrainer/core/scripts/preprocess_script.py
@@ -139,8 +139,8 @@ class PreprocessScript(AbstractPreprocessScript):
             dataset["file_type"] = None
             dataset["seed"] = 0  # ignored
             dataset["batch_size"] = 8  # ignored
-            _ = dataset.pop("criterion")
-            _ = dataset.pop("transform")
+            dataset.pop("criterion")
+            dataset.pop("transform")
             features_path = dataset.pop("features_path")
             features_subdir = dataset["features_subdir"]
             dataset["features_subdir"] = None

--- a/autrainer/core/scripts/preprocess_script.py
+++ b/autrainer/core/scripts/preprocess_script.py
@@ -141,7 +141,7 @@ class PreprocessScript(AbstractPreprocessScript):
             dataset["batch_size"] = 8  # ignored
             dataset.pop("criterion")
             dataset.pop("transform")
-            features_path = dataset.pop("features_path")
+            features_path = dataset.pop("features_path", dataset["path"])
             features_subdir = dataset["features_subdir"]
             dataset["features_subdir"] = None
             data = autrainer.instantiate(dataset)

--- a/autrainer/core/scripts/preprocess_script.py
+++ b/autrainer/core/scripts/preprocess_script.py
@@ -81,6 +81,8 @@ def preprocess_main(
         (data.dev_dataset, "dev"),
         (data.test_dataset, "test"),
     ):
+        # TODO: dataloader underutilized
+        # workers only parallelize loading
         loader = torch.utils.data.DataLoader(
             dataset=d,
             shuffle=False,
@@ -129,12 +131,12 @@ class PreprocessScript(AbstractPreprocessScript):
             "-n",
             "--num-workers",
             type=int,
-            default=1,
+            default=0,
             metavar="N",
             required=False,
             help=(
-                "Number of workers (threads) to use for preprocessing. "
-                "Defaults to 1."
+                "Number of workers (subprocesses) to use for preprocessing. "
+                "Defaults to 0."
             ),
         )
         self.parser.add_argument(
@@ -145,7 +147,7 @@ class PreprocessScript(AbstractPreprocessScript):
             metavar="F",
             required=False,
             help=(
-                "Frequency of progress bar updates for each worker (thread). "
+                "Frequency of progress bar updates for each worker (subprocess). "
                 "If 0, the progress bar will be disabled. Defaults to 1."
             ),
         )
@@ -219,10 +221,10 @@ def preprocess(
     Args:
         override_kwargs: Additional Hydra override arguments to pass to the
             train script.
-        num_workers: Number of workers (threads) to use for preprocessing.
+        num_workers: Number of workers (subprocess) to use for preprocessing.
             Defaults to 1.
         update_frequency: Frequency of progress bar updates for each worker
-            (thread). If 0, the progress bar will be disabled. Defaults to 1.
+            (subprocess). If 0, the progress bar will be disabled. Defaults to 0.
         cfg_launcher: Use the launcher specified in the configuration instead
             of the Hydra basic launcher. Defaults to False.
         config_name: The name of the config (usually the file name without the

--- a/autrainer/core/scripts/preprocess_script.py
+++ b/autrainer/core/scripts/preprocess_script.py
@@ -186,9 +186,9 @@ class PreprocessScript(AbstractPreprocessScript):
         self._clean_up()
 
     def _assert_num_workers(self, num_workers: int) -> None:
-        if num_workers < 1:
+        if num_workers < 0:
             raise ValueError(
-                f"Number of workers '{num_workers}' must be >= 1."
+                f"Number of workers '{num_workers}' must be >= 0."
             )
 
     def _preprocess_datasets(self) -> None:

--- a/autrainer/core/scripts/preprocess_script.py
+++ b/autrainer/core/scripts/preprocess_script.py
@@ -122,6 +122,9 @@ class PreprocessScript(AbstractPreprocessScript):
             self.datasets.items(), self.preprocessing.values()
         ):
             print(f" - {name}")
+            if preprocess is None:
+                print("No preprocessing specified. Skipping...")
+                continue
             # swap dataset handler with preprocessing handler
             features_subdir = dataset["features_subdir"]
             output_file_handler = autrainer.instantiate_shorthand(
@@ -134,8 +137,6 @@ class PreprocessScript(AbstractPreprocessScript):
             dataset["features_subdir"] = None
             dataset["file_handler"] = preprocess["file_handler"]
             dataset["file_type"] = preprocess["file_type"]
-            if preprocess is None:
-                continue
             data = autrainer.instantiate_shorthand(dataset)
             loader = torch.utils.data.DataLoader(
                 torch.utils.data.ConcatDataset(

--- a/autrainer/core/scripts/preprocess_script.py
+++ b/autrainer/core/scripts/preprocess_script.py
@@ -1,8 +1,8 @@
 from dataclasses import dataclass
-import torch
-from typing import Any, List, Optional
+from typing import Optional
 
 from omegaconf import DictConfig, OmegaConf
+import torch
 
 import autrainer
 from autrainer.core.scripts.abstract_script import MockParser
@@ -111,7 +111,6 @@ class PreprocessScript(AbstractPreprocessScript):
         import os
         from pathlib import Path
 
-        import pandas as pd
         from tqdm import tqdm
 
         from autrainer.datasets.utils import AbstractFileHandler
@@ -133,7 +132,7 @@ class PreprocessScript(AbstractPreprocessScript):
                 instance_of=AbstractFileHandler,
             )
             output_file_type = dataset["file_type"]
-            
+
             # override dataset file handling to work with raw audio
             dataset["file_handler"] = preprocess["file_handler"]
             # None allows dataset to work with all audio files
@@ -162,15 +161,15 @@ class PreprocessScript(AbstractPreprocessScript):
                     dataset=d,
                     shuffle=False,
                     num_workers=self.num_workers,
-                    batch_size=1  #TODO: can we do it batched?
+                    batch_size=1,  # TODO: can we do it batched?
                 )
                 for data in tqdm.tqdm(
                     loader,
                     total=len(loader),
                     desc=f"{name}-{n}",
-                    disable=self.update_frequency == 0
+                    disable=self.update_frequency == 0,
                 ):
-                    #TODO: will be streamlined once we switch to dataclass
+                    # TODO: will be streamlined once we switch to dataclass
                     index = d.df.index[data[2]]
                     item_path = d.df.loc[index, d.index_column]
                     out_path = Path(
@@ -181,10 +180,7 @@ class PreprocessScript(AbstractPreprocessScript):
                     os.makedirs(os.path.dirname(out_path), exist_ok=True)
                     if os.path.exists(out_path):
                         continue
-                    output_file_handler.save(
-                        out_path,
-                        pipeline(data[0], 0)
-                    )
+                    output_file_handler.save(out_path, pipeline(data[0], 0))
 
 
 @catch_cli_errors

--- a/autrainer/core/scripts/preprocess_script.py
+++ b/autrainer/core/scripts/preprocess_script.py
@@ -210,7 +210,7 @@ class PreprocessScript(AbstractPreprocessScript):
 @catch_cli_errors
 def preprocess(
     override_kwargs: Optional[dict] = None,
-    num_workers: int = 1,
+    num_workers: int = 0,
     update_frequency: int = 1,
     cfg_launcher: bool = False,
     config_name: str = "config",
@@ -222,9 +222,9 @@ def preprocess(
         override_kwargs: Additional Hydra override arguments to pass to the
             train script.
         num_workers: Number of workers (subprocess) to use for preprocessing.
-            Defaults to 1.
-        update_frequency: Frequency of progress bar updates for each worker
-            (subprocess). If 0, the progress bar will be disabled. Defaults to 0.
+            Defaults to 0.
+        update_frequency: Frequency of progress bar updates.
+            If 0, the progress bar will be disabled. Defaults to 1.
         cfg_launcher: Use the launcher specified in the configuration instead
             of the Hydra basic launcher. Defaults to False.
         config_name: The name of the config (usually the file name without the

--- a/autrainer/datasets/abstract_dataset.py
+++ b/autrainer/datasets/abstract_dataset.py
@@ -353,6 +353,9 @@ class BaseClassificationDataset(AbstractDataset):
         Args:
             path: Root path to the dataset.
             features_subdir: Subdirectory containing the features.
+                If `None`, defaults to audio subdirectory,
+                which is `default` for the standard format,
+                but can be overridden in the dataset specification.
             seed: Seed for reproducibility.
             metrics: List of metrics to calculate.
             tracking_metric: Metric to track.
@@ -438,6 +441,9 @@ class BaseMLClassificationDataset(AbstractDataset):
         Args:
             path: Root path to the dataset.
             features_subdir: Subdirectory containing the features.
+                If `None`, defaults to audio subdirectory,
+                which is `default` for the standard format,
+                but can be overridden in the dataset specification.
             seed: Seed for reproducibility.
             metrics: List of metrics to calculate.
             tracking_metric: Metric to track.
@@ -536,6 +542,9 @@ class BaseRegressionDataset(AbstractDataset):
         Args:
             path: Root path to the dataset.
             features_subdir: Subdirectory containing the features.
+                If `None`, defaults to audio subdirectory,
+                which is `default` for the standard format,
+                but can be overridden in the dataset specification.
             seed: Seed for reproducibility.
             metrics: List of metrics to calculate.
             tracking_metric: Metric to track.
@@ -612,6 +621,9 @@ class BaseMTRegressionDataset(AbstractDataset):
         Args:
             path: Root path to the dataset.
             features_subdir: Subdirectory containing the features.
+                If `None`, defaults to audio subdirectory,
+                which is `default` for the standard format,
+                but can be overridden in the dataset specification.
             seed: Seed for reproducibility.
             metrics: List of metrics to calculate.
             tracking_metric: Metric to track.

--- a/autrainer/datasets/abstract_dataset.py
+++ b/autrainer/datasets/abstract_dataset.py
@@ -52,6 +52,9 @@ class AbstractDataset(ABC):
         Args:
             path: Root path to the dataset.
             features_subdir: Subdirectory containing the features.
+                If `None`, defaults to audio subdirectory,
+                which is `default` for the standard format,
+                but can be overriden in the dataset specification.
             seed: Seed for reproducibility.
             task: Task of the dataset in
                 :const:`~autrainer.core.constants.TrainingConstants.TASKS`.
@@ -73,9 +76,11 @@ class AbstractDataset(ABC):
             stratify: Columns to stratify the dataset on. Defaults to None.
         """
         self._assert_task(task)
-        self._assert_directory(path, features_subdir)
-        self.path = path
         self.features_subdir = features_subdir
+        if self.features_subdir is None:
+            self.features_subdir = self.audio_subdir
+        self.path = path
+        self._assert_directory(self.path, self.features_subdir)
         self.seed = seed
         self.task = task
         self.metrics = [self._init_metric(m) for m in metrics]
@@ -94,6 +99,16 @@ class AbstractDataset(ABC):
         self._generator = torch.Generator().manual_seed(self.seed)
         self.df_train, self.df_dev, self.df_test = self.load_dataframes()
         self._assert_stratify()
+
+    @property
+    def audio_subdir(self):
+        """Subfolder containing audio data.
+
+        Defaults to `default` for our standard format.
+        Should be overriden for datasets
+        that do not conform to it.
+        """
+        return "default"
 
     @staticmethod
     def _assert_task(task: str) -> None:

--- a/autrainer/datasets/abstract_dataset.py
+++ b/autrainer/datasets/abstract_dataset.py
@@ -41,6 +41,7 @@ class AbstractDataset(ABC):
         file_type: str,
         file_handler: Union[str, DictConfig, Dict],
         batch_size: int,
+        features_path: Optional[str] = None,
         inference_batch_size: Optional[int] = None,
         train_transform: Optional[SmartCompose] = None,
         dev_transform: Optional[SmartCompose] = None,
@@ -65,6 +66,10 @@ class AbstractDataset(ABC):
             file_type: File type of the features.
             file_handler: File handler to load the data.
             batch_size: Batch size.
+            features_path: Root path to features. Useful
+                when features need to be extracted and store
+                in a different folder than the root of the dataset.
+                If `None`, will be set to `path`. Defaults to `None`.
             inference_batch_size: Inference batch size. If None, defaults to
                 batch_size. Defaults to None.
             train_transform: Transform to apply to the training set.
@@ -80,7 +85,10 @@ class AbstractDataset(ABC):
         if self.features_subdir is None:
             self.features_subdir = self.audio_subdir
         self.path = path
-        self._assert_directory(self.path, self.features_subdir)
+        self.features_path = features_path
+        if self.features_path is None:
+            self.features_path = self.path
+        self._assert_directory(self.features_path, self.features_subdir)
         self.seed = seed
         self.task = task
         self.metrics = [self._init_metric(m) for m in metrics]
@@ -216,7 +224,7 @@ class AbstractDataset(ABC):
             Initialized dataset.
         """
         return DatasetWrapper(
-            path=self.path,
+            path=self.features_path,
             features_subdir=self.features_subdir,
             index_column=self.index_column,
             target_column=self.target_column,
@@ -334,6 +342,7 @@ class BaseClassificationDataset(AbstractDataset):
         file_handler: Union[str, DictConfig, Dict],
         batch_size: int,
         inference_batch_size: Optional[int] = None,
+        features_path: Optional[str] = None,
         train_transform: Optional[SmartCompose] = None,
         dev_transform: Optional[SmartCompose] = None,
         test_transform: Optional[SmartCompose] = None,
@@ -352,6 +361,10 @@ class BaseClassificationDataset(AbstractDataset):
             file_type: File type of the features.
             file_handler: File handler to load the data.
             batch_size: Batch size.
+            features_path: Root path to features. Useful
+                when features need to be extracted and store
+                in a different folder than the root of the dataset.
+                If `None`, will be set to `path`. Defaults to `None`.
             inference_batch_size: Inference batch size. If None, defaults to
                 batch_size. Defaults to None.
             train_transform: Transform to apply to the training set.
@@ -375,6 +388,7 @@ class BaseClassificationDataset(AbstractDataset):
             file_handler=file_handler,
             batch_size=batch_size,
             inference_batch_size=inference_batch_size,
+            features_path=features_path,
             train_transform=train_transform,
             dev_transform=dev_transform,
             test_transform=test_transform,
@@ -411,6 +425,7 @@ class BaseMLClassificationDataset(AbstractDataset):
         file_type: str,
         file_handler: Union[str, DictConfig, Dict],
         batch_size: int,
+        features_path: Optional[str] = None,
         inference_batch_size: Optional[int] = None,
         train_transform: Optional[SmartCompose] = None,
         dev_transform: Optional[SmartCompose] = None,
@@ -431,6 +446,10 @@ class BaseMLClassificationDataset(AbstractDataset):
             file_type: File type of the features.
             file_handler: File handler to load the data.
             batch_size: Batch size.
+            features_path: Root path to features. Useful
+                when features need to be extracted and store
+                in a different folder than the root of the dataset.
+                If `None`, will be set to `path`. Defaults to `None`.
             inference_batch_size: Inference batch size. If None, defaults to
                 batch_size. Defaults to None.
             train_transform: Transform to apply to the training set.
@@ -456,6 +475,7 @@ class BaseMLClassificationDataset(AbstractDataset):
             file_type=file_type,
             file_handler=file_handler,
             batch_size=batch_size,
+            features_path=features_path,
             inference_batch_size=inference_batch_size,
             train_transform=train_transform,
             dev_transform=dev_transform,
@@ -504,6 +524,7 @@ class BaseRegressionDataset(AbstractDataset):
         file_type: str,
         file_handler: Union[str, DictConfig, Dict],
         batch_size: int,
+        features_path: Optional[str] = None,
         inference_batch_size: Optional[int] = None,
         train_transform: Optional[SmartCompose] = None,
         dev_transform: Optional[SmartCompose] = None,
@@ -523,6 +544,10 @@ class BaseRegressionDataset(AbstractDataset):
             file_type: File type of the features.
             file_handler: File handler to load the data.
             batch_size: Batch size.
+            features_path: Root path to features. Useful
+                when features need to be extracted and store
+                in a different folder than the root of the dataset.
+                If `None`, will be set to `path`. Defaults to `None`.
             inference_batch_size: Inference batch size. If None, defaults to
                 batch_size. Defaults to None.
             train_transform: Transform to apply to the training set.
@@ -545,6 +570,7 @@ class BaseRegressionDataset(AbstractDataset):
             file_type=file_type,
             file_handler=file_handler,
             batch_size=batch_size,
+            features_path=features_path,
             inference_batch_size=inference_batch_size,
             train_transform=train_transform,
             dev_transform=dev_transform,
@@ -574,6 +600,7 @@ class BaseMTRegressionDataset(AbstractDataset):
         file_type: str,
         file_handler: Union[str, DictConfig, Dict],
         batch_size: int,
+        features_path: Optional[str] = None,
         inference_batch_size: Optional[int] = None,
         train_transform: Optional[SmartCompose] = None,
         dev_transform: Optional[SmartCompose] = None,
@@ -593,6 +620,10 @@ class BaseMTRegressionDataset(AbstractDataset):
             file_type: File type of the features.
             file_handler: File handler to load the data.
             batch_size: Batch size.
+            features_path: Root path to features. Useful
+                when features need to be extracted and store
+                in a different folder than the root of the dataset.
+                If `None`, will be set to `path`. Defaults to `None`.
             inference_batch_size: Inference batch size. If None, defaults to
                 batch_size. Defaults to None.
             train_transform: Transform to apply to the training set.
@@ -615,6 +646,7 @@ class BaseMTRegressionDataset(AbstractDataset):
             file_type=file_type,
             file_handler=file_handler,
             batch_size=batch_size,
+            features_path=features_path,
             inference_batch_size=inference_batch_size,
             train_transform=train_transform,
             dev_transform=dev_transform,

--- a/autrainer/datasets/abstract_dataset.py
+++ b/autrainer/datasets/abstract_dataset.py
@@ -54,7 +54,7 @@ class AbstractDataset(ABC):
             features_subdir: Subdirectory containing the features.
                 If `None`, defaults to audio subdirectory,
                 which is `default` for the standard format,
-                but can be overriden in the dataset specification.
+                but can be overridden in the dataset specification.
             seed: Seed for reproducibility.
             task: Task of the dataset in
                 :const:`~autrainer.core.constants.TrainingConstants.TASKS`.
@@ -105,7 +105,7 @@ class AbstractDataset(ABC):
         """Subfolder containing audio data.
 
         Defaults to `default` for our standard format.
-        Should be overriden for datasets
+        Should be overridden for datasets
         that do not conform to it.
         """
         return "default"

--- a/autrainer/datasets/abstract_dataset.py
+++ b/autrainer/datasets/abstract_dataset.py
@@ -67,7 +67,7 @@ class AbstractDataset(ABC):
             file_handler: File handler to load the data.
             batch_size: Batch size.
             features_path: Root path to features. Useful
-                when features need to be extracted and store
+                when features need to be extracted and stored
                 in a different folder than the root of the dataset.
                 If `None`, will be set to `path`. Defaults to `None`.
             inference_batch_size: Inference batch size. If None, defaults to
@@ -362,7 +362,7 @@ class BaseClassificationDataset(AbstractDataset):
             file_handler: File handler to load the data.
             batch_size: Batch size.
             features_path: Root path to features. Useful
-                when features need to be extracted and store
+                when features need to be extracted and stored
                 in a different folder than the root of the dataset.
                 If `None`, will be set to `path`. Defaults to `None`.
             inference_batch_size: Inference batch size. If None, defaults to
@@ -447,7 +447,7 @@ class BaseMLClassificationDataset(AbstractDataset):
             file_handler: File handler to load the data.
             batch_size: Batch size.
             features_path: Root path to features. Useful
-                when features need to be extracted and store
+                when features need to be extracted and stored
                 in a different folder than the root of the dataset.
                 If `None`, will be set to `path`. Defaults to `None`.
             inference_batch_size: Inference batch size. If None, defaults to
@@ -545,7 +545,7 @@ class BaseRegressionDataset(AbstractDataset):
             file_handler: File handler to load the data.
             batch_size: Batch size.
             features_path: Root path to features. Useful
-                when features need to be extracted and store
+                when features need to be extracted and stored
                 in a different folder than the root of the dataset.
                 If `None`, will be set to `path`. Defaults to `None`.
             inference_batch_size: Inference batch size. If None, defaults to
@@ -621,7 +621,7 @@ class BaseMTRegressionDataset(AbstractDataset):
             file_handler: File handler to load the data.
             batch_size: Batch size.
             features_path: Root path to features. Useful
-                when features need to be extracted and store
+                when features need to be extracted and stored
                 in a different folder than the root of the dataset.
                 If `None`, will be set to `path`. Defaults to `None`.
             inference_batch_size: Inference batch size. If None, defaults to

--- a/autrainer/datasets/abstract_dataset.py
+++ b/autrainer/datasets/abstract_dataset.py
@@ -169,10 +169,22 @@ class AbstractDataset(ABC):
             Dataframes for training, development, and testing.
         """
         return (
-            pd.read_csv(os.path.join(self.path, "train.csv")),
-            pd.read_csv(os.path.join(self.path, "dev.csv")),
-            pd.read_csv(os.path.join(self.path, "test.csv")),
+            self.train_df,
+            self.dev_df,
+            self.test_df,
         )
+
+    @cached_property
+    def train_df(self):
+        return pd.read_csv(os.path.join(self.path, "train.csv"))
+
+    @cached_property
+    def dev_df(self):
+        return pd.read_csv(os.path.join(self.path, "dev.csv"))
+
+    @cached_property
+    def test_df(self):
+        return pd.read_csv(os.path.join(self.path, "test.csv"))
 
     def _init_dataset(
         self,

--- a/autrainer/datasets/aibo.py
+++ b/autrainer/datasets/aibo.py
@@ -42,6 +42,7 @@ class AIBO(BaseClassificationDataset):
         file_type: str,
         file_handler: Union[str, DictConfig, Dict],
         batch_size: int,
+        features_path: Optional[str] = None,
         inference_batch_size: Optional[int] = None,
         train_transform: Optional[SmartCompose] = None,
         dev_transform: Optional[SmartCompose] = None,
@@ -63,6 +64,10 @@ class AIBO(BaseClassificationDataset):
             file_type: File type of the features.
             file_handler: File handler to load the data.
             batch_size: Batch size.
+            features_path: Root path to features. Useful
+                when features need to be extracted and store
+                in a different folder than the root of the dataset.
+                If `None`, will be set to `path`. Defaults to `None`.
             inference_batch_size: Inference batch size. If None, defaults to
                 batch_size. Defaults to None.
             train_transform: Transform to apply to the training set.
@@ -88,6 +93,7 @@ class AIBO(BaseClassificationDataset):
             file_type=file_type,
             file_handler=file_handler,
             batch_size=batch_size,
+            features_path=features_path,
             inference_batch_size=inference_batch_size,
             train_transform=train_transform,
             dev_transform=dev_transform,

--- a/autrainer/datasets/aibo.py
+++ b/autrainer/datasets/aibo.py
@@ -134,7 +134,6 @@ class AIBO(BaseClassificationDataset):
         df["file"] = df["id"].apply(lambda x: x + ".wav")
         df["school"] = df["id"].apply(lambda x: x.split("_")[0])
         df["speaker"] = df["id"].apply(lambda x: x.split("_")[1])
-        df = df.set_index("file")
         return df
 
     @cached_property

--- a/autrainer/datasets/aibo.py
+++ b/autrainer/datasets/aibo.py
@@ -65,7 +65,7 @@ class AIBO(BaseClassificationDataset):
             file_handler: File handler to load the data.
             batch_size: Batch size.
             features_path: Root path to features. Useful
-                when features need to be extracted and store
+                when features need to be extracted and stored
                 in a different folder than the root of the dataset.
                 If `None`, will be set to `path`. Defaults to `None`.
             inference_batch_size: Inference batch size. If None, defaults to

--- a/autrainer/datasets/aibo.py
+++ b/autrainer/datasets/aibo.py
@@ -56,6 +56,9 @@ class AIBO(BaseClassificationDataset):
         Args:
             path: Root path to the dataset.
             features_subdir: Subdirectory containing the features.
+                If `None`, defaults to audio subdirectory,
+                which is `default` for the standard format,
+                but can be overridden in the dataset specification.
             seed: Seed for reproducibility.
             metrics: List of metrics to calculate.
             tracking_metric: Metric to track.

--- a/autrainer/datasets/aibo.py
+++ b/autrainer/datasets/aibo.py
@@ -123,9 +123,11 @@ class AIBO(BaseClassificationDataset):
         return "wav"
 
     @cached_property
-    def _load_df(self, path):
+    def _load_df(self) -> pd.DataFrame:
         df = pd.read_csv(
-            os.path.join(path, f"chunk_labels_{self.aibo_task}_corpus.txt"),
+            os.path.join(
+                self.path, f"chunk_labels_{self.aibo_task}_corpus.txt"
+            ),
             header=None,
             sep=" ",
         )
@@ -137,7 +139,7 @@ class AIBO(BaseClassificationDataset):
         return df
 
     @cached_property
-    def train_df(self):
+    def train_df(self) -> pd.DataFrame:
         df = self._load_df()
         df_train_dev = df.loc[df["school"] == "Ohm"]
         speakers = sorted(df_train_dev["speaker"].unique())
@@ -147,7 +149,7 @@ class AIBO(BaseClassificationDataset):
         return df_train
 
     @cached_property
-    def dev_df(self):
+    def dev_df(self) -> pd.DataFrame:
         df = self._load_df()
         df_train_dev = df.loc[df["school"] == "Ohm"]
         speakers = sorted(df_train_dev["speaker"].unique())
@@ -155,7 +157,7 @@ class AIBO(BaseClassificationDataset):
         return df_dev
 
     @cached_property
-    def test_df(self):
+    def test_df(self) -> pd.DataFrame:
         df = self._load_df()
         df_test = df.loc[df["school"] == "Mont"]
         return df_test

--- a/autrainer/datasets/aibo.py
+++ b/autrainer/datasets/aibo.py
@@ -103,7 +103,6 @@ class AIBO(BaseClassificationDataset):
         self.standardize = standardize
         if self.standardize:
             train_data = torch.cat([x for x, *_ in self.train_dataset])
-            print(train_data.mean(0).shape, train_data.std(0).shape)
             standardizer = Standardizer(
                 mean=train_data.mean(0).tolist(),
                 std=train_data.std(0).tolist(),

--- a/autrainer/datasets/aibo.py
+++ b/autrainer/datasets/aibo.py
@@ -1,6 +1,6 @@
 from functools import cached_property
 import os
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Union
 
 from omegaconf import DictConfig
 import pandas as pd
@@ -139,15 +139,13 @@ class AIBO(BaseClassificationDataset):
             df_train_dev["speaker"].isin(speakers[:-2])
         ]
         return df_train
-    
+
     @cached_property
     def dev_df(self):
         df = self._load_df()
         df_train_dev = df.loc[df["school"] == "Ohm"]
         speakers = sorted(df_train_dev["speaker"].unique())
-        df_dev = df_train_dev.loc[
-            df_train_dev["speaker"].isin(speakers[-2:])
-        ]
+        df_dev = df_train_dev.loc[df_train_dev["speaker"].isin(speakers[-2:])]
         return df_dev
 
     @cached_property

--- a/autrainer/datasets/aibo.py
+++ b/autrainer/datasets/aibo.py
@@ -111,6 +111,11 @@ class AIBO(BaseClassificationDataset):
                 self.df_train, self.train_transform
             )
 
+    @property
+    def audio_subdir(self):
+        """Subfolder containing audio data."""
+        return "wav"
+
     @cached_property
     def _load_df(self, path):
         df = pd.read_csv(

--- a/autrainer/datasets/aibo.py
+++ b/autrainer/datasets/aibo.py
@@ -139,7 +139,7 @@ class AIBO(BaseClassificationDataset):
 
     @cached_property
     def train_df(self) -> pd.DataFrame:
-        df = self._load_df()
+        df = self._load_df
         df_train_dev = df.loc[df["school"] == "Ohm"]
         speakers = sorted(df_train_dev["speaker"].unique())
         df_train = df_train_dev.loc[
@@ -149,7 +149,7 @@ class AIBO(BaseClassificationDataset):
 
     @cached_property
     def dev_df(self) -> pd.DataFrame:
-        df = self._load_df()
+        df = self._load_df
         df_train_dev = df.loc[df["school"] == "Ohm"]
         speakers = sorted(df_train_dev["speaker"].unique())
         df_dev = df_train_dev.loc[df_train_dev["speaker"].isin(speakers[-2:])]
@@ -157,7 +157,7 @@ class AIBO(BaseClassificationDataset):
 
     @cached_property
     def test_df(self) -> pd.DataFrame:
-        df = self._load_df()
+        df = self._load_df
         df_test = df.loc[df["school"] == "Mont"]
         return df_test
 

--- a/autrainer/datasets/dcase_2016_t1.py
+++ b/autrainer/datasets/dcase_2016_t1.py
@@ -1,7 +1,8 @@
+from functools import cached_property
 import os
 from pathlib import Path
 import shutil
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Union
 
 from omegaconf import DictConfig
 import pandas as pd
@@ -96,16 +97,17 @@ class DCASE2016Task1(BaseClassificationDataset):
             stratify=stratify,
         )
 
-    def load_dataframes(
-        self,
-    ) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
-        return (
-            pd.read_csv(os.path.join(self.path, f"fold{self.fold}_train.csv")),
-            pd.read_csv(
-                os.path.join(self.path, f"fold{self.fold}_evaluate.csv")
-            ),
-            pd.read_csv(os.path.join(self.path, "test.csv")),
-        )
+    @cached_property
+    def train_df(self):
+        return pd.read_csv(os.path.join(self.path, f"fold{self.fold}_train.csv"))
+
+    @cached_property
+    def dev_df(self):
+        return pd.read_csv(os.path.join(self.path, f"fold{self.fold}_evaluate.csv"))
+
+    @cached_property
+    def test_df(self):
+        return pd.read_csv(os.path.join(self.path, f"test.csv"))
 
     @staticmethod
     def download(path: str) -> None:  # pragma: no cover

--- a/autrainer/datasets/dcase_2016_t1.py
+++ b/autrainer/datasets/dcase_2016_t1.py
@@ -99,15 +99,19 @@ class DCASE2016Task1(BaseClassificationDataset):
 
     @cached_property
     def train_df(self):
-        return pd.read_csv(os.path.join(self.path, f"fold{self.fold}_train.csv"))
+        return pd.read_csv(
+            os.path.join(self.path, f"fold{self.fold}_train.csv")
+        )
 
     @cached_property
     def dev_df(self):
-        return pd.read_csv(os.path.join(self.path, f"fold{self.fold}_evaluate.csv"))
+        return pd.read_csv(
+            os.path.join(self.path, f"fold{self.fold}_evaluate.csv")
+        )
 
     @cached_property
     def test_df(self):
-        return pd.read_csv(os.path.join(self.path, f"test.csv"))
+        return pd.read_csv(os.path.join(self.path, "test.csv"))
 
     @staticmethod
     def download(path: str) -> None:  # pragma: no cover

--- a/autrainer/datasets/dcase_2016_t1.py
+++ b/autrainer/datasets/dcase_2016_t1.py
@@ -68,7 +68,7 @@ class DCASE2016Task1(BaseClassificationDataset):
             file_handler: File handler to load the data.
             batch_size: Batch size.
             features_path: Root path to features. Useful
-                when features need to be extracted and store
+                when features need to be extracted and stored
                 in a different folder than the root of the dataset.
                 If `None`, will be set to `path`. Defaults to `None`.
             inference_batch_size: Inference batch size. If None, defaults to

--- a/autrainer/datasets/dcase_2016_t1.py
+++ b/autrainer/datasets/dcase_2016_t1.py
@@ -46,6 +46,7 @@ class DCASE2016Task1(BaseClassificationDataset):
         file_type: str,
         file_handler: Union[str, DictConfig, Dict],
         batch_size: int,
+        features_path: Optional[str] = None,
         inference_batch_size: Optional[int] = None,
         train_transform: Optional[SmartCompose] = None,
         dev_transform: Optional[SmartCompose] = None,
@@ -66,6 +67,10 @@ class DCASE2016Task1(BaseClassificationDataset):
             file_type: File type of the features.
             file_handler: File handler to load the data.
             batch_size: Batch size.
+            features_path: Root path to features. Useful
+                when features need to be extracted and store
+                in a different folder than the root of the dataset.
+                If `None`, will be set to `path`. Defaults to `None`.
             inference_batch_size: Inference batch size. If None, defaults to
                 batch_size. Defaults to None.
             train_transform: Transform to apply to the training set.
@@ -90,6 +95,7 @@ class DCASE2016Task1(BaseClassificationDataset):
             file_type=file_type,
             file_handler=file_handler,
             batch_size=batch_size,
+            features_path=features_path,
             inference_batch_size=inference_batch_size,
             train_transform=train_transform,
             dev_transform=dev_transform,

--- a/autrainer/datasets/dcase_2016_t1.py
+++ b/autrainer/datasets/dcase_2016_t1.py
@@ -59,6 +59,9 @@ class DCASE2016Task1(BaseClassificationDataset):
         Args:
             path: Root path to the dataset.
             features_subdir: Subdirectory containing the features.
+                If `None`, defaults to audio subdirectory,
+                which is `default` for the standard format,
+                but can be overridden in the dataset specification.
             seed: Seed for reproducibility.
             metrics: List of metrics to calculate.
             tracking_metric: Metric to track.

--- a/autrainer/datasets/dcase_2018_t3.py
+++ b/autrainer/datasets/dcase_2018_t3.py
@@ -49,6 +49,9 @@ class DCASE2018Task3(BaseClassificationDataset):
         Args:
             path: Root path to the dataset.
             features_subdir: Subdirectory containing the features.
+                If `None`, defaults to audio subdirectory,
+                which is `default` for the standard format,
+                but can be overridden in the dataset specification.
             seed: Seed for reproducibility.
             metrics: List of metrics to calculate.
             tracking_metric: Metric to track.

--- a/autrainer/datasets/dcase_2018_t3.py
+++ b/autrainer/datasets/dcase_2018_t3.py
@@ -35,6 +35,7 @@ class DCASE2018Task3(BaseClassificationDataset):
         file_type: str,
         file_handler: Union[str, DictConfig, Dict],
         batch_size: int,
+        features_path: Optional[str] = None,
         inference_batch_size: Optional[int] = None,
         train_transform: Optional[SmartCompose] = None,
         dev_transform: Optional[SmartCompose] = None,
@@ -56,6 +57,10 @@ class DCASE2018Task3(BaseClassificationDataset):
             file_type: File type of the features.
             file_handler: File handler to load the data.
             batch_size: Batch size.
+            features_path: Root path to features. Useful
+                when features need to be extracted and store
+                in a different folder than the root of the dataset.
+                If `None`, will be set to `path`. Defaults to `None`.
             inference_batch_size: Inference batch size. If None, defaults to
                 batch_size. Defaults to None.
             train_transform: Transform to apply to the training set.
@@ -84,6 +89,7 @@ class DCASE2018Task3(BaseClassificationDataset):
             file_type=file_type,
             file_handler=file_handler,
             batch_size=batch_size,
+            features_path=features_path,
             inference_batch_size=inference_batch_size,
             train_transform=train_transform,
             dev_transform=dev_transform,

--- a/autrainer/datasets/dcase_2018_t3.py
+++ b/autrainer/datasets/dcase_2018_t3.py
@@ -58,7 +58,7 @@ class DCASE2018Task3(BaseClassificationDataset):
             file_handler: File handler to load the data.
             batch_size: Batch size.
             features_path: Root path to features. Useful
-                when features need to be extracted and store
+                when features need to be extracted and stored
                 in a different folder than the root of the dataset.
                 If `None`, will be set to `path`. Defaults to `None`.
             inference_batch_size: Inference batch size. If None, defaults to

--- a/autrainer/datasets/dcase_2020_t1a.py
+++ b/autrainer/datasets/dcase_2020_t1a.py
@@ -57,6 +57,7 @@ class DCASE2020Task1A(BaseClassificationDataset):
         file_type: str,
         file_handler: Union[str, DictConfig, Dict],
         batch_size: int,
+        features_path: Optional[str] = None,
         inference_batch_size: Optional[int] = None,
         train_transform: Optional[SmartCompose] = None,
         dev_transform: Optional[SmartCompose] = None,
@@ -81,6 +82,10 @@ class DCASE2020Task1A(BaseClassificationDataset):
             file_type: File type of the features.
             file_handler: File handler to load the data.
             batch_size: Batch size.
+            features_path: Root path to features. Useful
+                when features need to be extracted and store
+                in a different folder than the root of the dataset.
+                If `None`, will be set to `path`. Defaults to `None`.
             inference_batch_size: Inference batch size. If None, defaults to
                 batch_size. Defaults to None.
             train_transform: Transform to apply to the training set.
@@ -116,6 +121,7 @@ class DCASE2020Task1A(BaseClassificationDataset):
             file_type=file_type,
             file_handler=file_handler,
             batch_size=batch_size,
+            features_path=features_path,
             inference_batch_size=inference_batch_size,
             train_transform=train_transform,
             dev_transform=dev_transform,

--- a/autrainer/datasets/dcase_2020_t1a.py
+++ b/autrainer/datasets/dcase_2020_t1a.py
@@ -83,7 +83,7 @@ class DCASE2020Task1A(BaseClassificationDataset):
             file_handler: File handler to load the data.
             batch_size: Batch size.
             features_path: Root path to features. Useful
-                when features need to be extracted and store
+                when features need to be extracted and stored
                 in a different folder than the root of the dataset.
                 If `None`, will be set to `path`. Defaults to `None`.
             inference_batch_size: Inference batch size. If None, defaults to

--- a/autrainer/datasets/dcase_2020_t1a.py
+++ b/autrainer/datasets/dcase_2020_t1a.py
@@ -74,6 +74,9 @@ class DCASE2020Task1A(BaseClassificationDataset):
         Args:
             path: Root path to the dataset.
             features_subdir: Subdirectory containing the features.
+                If `None`, defaults to audio subdirectory,
+                which is `default` for the standard format,
+                but can be overridden in the dataset specification.
             seed: Seed for reproducibility.
             metrics: List of metrics to calculate.
             tracking_metric: Metric to track.

--- a/autrainer/datasets/edansa2019.py
+++ b/autrainer/datasets/edansa2019.py
@@ -29,6 +29,7 @@ class EDANSA2019(BaseMLClassificationDataset):
         file_type: str,
         file_handler: Union[str, DictConfig, Dict],
         batch_size: int,
+        features_path: Optional[str] = None,
         inference_batch_size: Optional[int] = None,
         train_transform: Optional[SmartCompose] = None,
         dev_transform: Optional[SmartCompose] = None,
@@ -49,6 +50,10 @@ class EDANSA2019(BaseMLClassificationDataset):
             file_type: File type of the features.
             file_handler: File handler to load the data.
             batch_size: Batch size.
+            features_path: Root path to features. Useful
+                when features need to be extracted and store
+                in a different folder than the root of the dataset.
+                If `None`, will be set to `path`. Defaults to `None`.
             inference_batch_size: Inference batch size. If None, defaults to
                 batch_size. Defaults to None.
             train_transform: Transform to apply to the training set.
@@ -71,6 +76,7 @@ class EDANSA2019(BaseMLClassificationDataset):
             file_type=file_type,
             file_handler=file_handler,
             batch_size=batch_size,
+            features_path=features_path,
             inference_batch_size=inference_batch_size,
             train_transform=train_transform,
             dev_transform=dev_transform,

--- a/autrainer/datasets/edansa2019.py
+++ b/autrainer/datasets/edansa2019.py
@@ -42,6 +42,9 @@ class EDANSA2019(BaseMLClassificationDataset):
         Args:
             path: Root path to the dataset.
             features_subdir: Subdirectory containing the features.
+                If `None`, defaults to audio subdirectory,
+                which is `default` for the standard format,
+                but can be overridden in the dataset specification.
             seed: Seed for reproducibility.
             metrics: List of metrics to calculate.
             tracking_metric: Metric to track.

--- a/autrainer/datasets/edansa2019.py
+++ b/autrainer/datasets/edansa2019.py
@@ -51,7 +51,7 @@ class EDANSA2019(BaseMLClassificationDataset):
             file_handler: File handler to load the data.
             batch_size: Batch size.
             features_path: Root path to features. Useful
-                when features need to be extracted and store
+                when features need to be extracted and stored
                 in a different folder than the root of the dataset.
                 If `None`, will be set to `path`. Defaults to `None`.
             inference_batch_size: Inference batch size. If None, defaults to

--- a/autrainer/datasets/emo_db.py
+++ b/autrainer/datasets/emo_db.py
@@ -62,7 +62,7 @@ class EmoDB(BaseClassificationDataset):
             file_handler: File handler to load the data.
             batch_size: Batch size.
             features_path: Root path to features. Useful
-                when features need to be extracted and store
+                when features need to be extracted and stored
                 in a different folder than the root of the dataset.
                 If `None`, will be set to `path`. Defaults to `None`.
             inference_batch_size: Inference batch size. If None, defaults to

--- a/autrainer/datasets/emo_db.py
+++ b/autrainer/datasets/emo_db.py
@@ -1,3 +1,4 @@
+from functools import cached_property
 import os
 import shutil
 from typing import Dict, List, Optional, Tuple, Union
@@ -96,15 +97,21 @@ class EmoDB(BaseClassificationDataset):
             stratify=stratify,
         )
 
-    def load_dataframes(
-        self,
-    ) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
-        meta = pd.read_csv(os.path.join(self.path, "metadata.csv"))
-        return (
-            meta[meta["speaker"].isin(self.train_speakers)],
-            meta[meta["speaker"].isin(self.dev_speakers)],
-            meta[meta["speaker"].isin(self.test_speakers)],
-        )
+    @cached_property
+    def meta(self):
+        return pd.read_csv(os.path.join(self.path, "metadata.csv"))
+    
+    @cached_property
+    def train_df(self):
+        return self.meta[self.meta["speaker"].isin(self.train_speakers)]
+
+    @cached_property
+    def dev_df(self):
+        return self.meta[self.meta["speaker"].isin(self.dev_speakers)]
+
+    @cached_property
+    def test_df(self):
+        return self.meta[self.meta["speaker"].isin(self.test_speakers)]
 
     @staticmethod
     def download(path: str) -> None:  # pragma: no cover

--- a/autrainer/datasets/emo_db.py
+++ b/autrainer/datasets/emo_db.py
@@ -38,6 +38,7 @@ class EmoDB(BaseClassificationDataset):
         file_type: str,
         file_handler: Union[str, DictConfig, Dict],
         batch_size: int,
+        features_path: Optional[str] = None,
         inference_batch_size: Optional[int] = None,
         train_transform: Optional[SmartCompose] = None,
         dev_transform: Optional[SmartCompose] = None,
@@ -60,6 +61,10 @@ class EmoDB(BaseClassificationDataset):
             file_type: File type of the features.
             file_handler: File handler to load the data.
             batch_size: Batch size.
+            features_path: Root path to features. Useful
+                when features need to be extracted and store
+                in a different folder than the root of the dataset.
+                If `None`, will be set to `path`. Defaults to `None`.
             inference_batch_size: Inference batch size. If None, defaults to
                 batch_size. Defaults to None.
             train_transform: Transform to apply to the training set.
@@ -91,6 +96,7 @@ class EmoDB(BaseClassificationDataset):
             file_handler=file_handler,
             batch_size=batch_size,
             inference_batch_size=inference_batch_size,
+            features_path=features_path,
             train_transform=train_transform,
             dev_transform=dev_transform,
             test_transform=test_transform,

--- a/autrainer/datasets/emo_db.py
+++ b/autrainer/datasets/emo_db.py
@@ -1,7 +1,7 @@
 from functools import cached_property
 import os
 import shutil
-from typing import Dict, List, Optional, Tuple, Union
+from typing import Dict, List, Optional, Union
 
 from omegaconf import DictConfig
 import pandas as pd
@@ -100,7 +100,7 @@ class EmoDB(BaseClassificationDataset):
     @cached_property
     def meta(self):
         return pd.read_csv(os.path.join(self.path, "metadata.csv"))
-    
+
     @cached_property
     def train_df(self):
         return self.meta[self.meta["speaker"].isin(self.train_speakers)]

--- a/autrainer/datasets/emo_db.py
+++ b/autrainer/datasets/emo_db.py
@@ -53,6 +53,9 @@ class EmoDB(BaseClassificationDataset):
         Args:
             path: Root path to the dataset.
             features_subdir: Subdirectory containing the features.
+                If `None`, defaults to audio subdirectory,
+                which is `default` for the standard format,
+                but can be overridden in the dataset specification.
             seed: Seed for reproducibility.
             metrics: List of metrics to calculate.
             tracking_metric: Metric to track.

--- a/autrainer/datasets/speech_commands.py
+++ b/autrainer/datasets/speech_commands.py
@@ -25,6 +25,7 @@ class SpeechCommands(BaseClassificationDataset):
         file_type: str,
         file_handler: Union[str, DictConfig, Dict],
         batch_size: int,
+        features_path: Optional[str] = None,
         inference_batch_size: Optional[int] = None,
         train_transform: Optional[SmartCompose] = None,
         dev_transform: Optional[SmartCompose] = None,
@@ -44,6 +45,10 @@ class SpeechCommands(BaseClassificationDataset):
             file_type: File type of the features.
             file_handler: File handler to load the data.
             batch_size: Batch size.
+            features_path: Root path to features. Useful
+                when features need to be extracted and store
+                in a different folder than the root of the dataset.
+                If `None`, will be set to `path`. Defaults to `None`.
             inference_batch_size: Inference batch size. If None, defaults to
                 batch_size. Defaults to None.
             train_transform: Transform to apply to the training set.
@@ -65,6 +70,7 @@ class SpeechCommands(BaseClassificationDataset):
             file_type=file_type,
             file_handler=file_handler,
             batch_size=batch_size,
+            features_path=features_path,
             inference_batch_size=inference_batch_size,
             train_transform=train_transform,
             dev_transform=dev_transform,

--- a/autrainer/datasets/speech_commands.py
+++ b/autrainer/datasets/speech_commands.py
@@ -46,7 +46,7 @@ class SpeechCommands(BaseClassificationDataset):
             file_handler: File handler to load the data.
             batch_size: Batch size.
             features_path: Root path to features. Useful
-                when features need to be extracted and store
+                when features need to be extracted and stored
                 in a different folder than the root of the dataset.
                 If `None`, will be set to `path`. Defaults to `None`.
             inference_batch_size: Inference batch size. If None, defaults to

--- a/autrainer/datasets/speech_commands.py
+++ b/autrainer/datasets/speech_commands.py
@@ -37,6 +37,9 @@ class SpeechCommands(BaseClassificationDataset):
         Args:
             path: Root path to the dataset.
             features_subdir: Subdirectory containing the features.
+                If `None`, defaults to audio subdirectory,
+                which is `default` for the standard format,
+                but can be overridden in the dataset specification.
             seed: Seed for reproducibility.
             metrics: List of metrics to calculate.
             tracking_metric: Metric to track.

--- a/autrainer/datasets/utils/dataset_wrapper.py
+++ b/autrainer/datasets/utils/dataset_wrapper.py
@@ -19,7 +19,7 @@ class DatasetWrapper(torch.utils.data.Dataset):
         target_column: Union[str, List[str]],
         file_handler: AbstractFileHandler,
         df: pd.DataFrame,
-        file_type: str = None,
+        file_type: Optional[str] = None,
         transform: Optional[SmartCompose] = None,
         target_transform: Optional[AbstractTargetTransform] = None,
     ):

--- a/autrainer/datasets/utils/dataset_wrapper.py
+++ b/autrainer/datasets/utils/dataset_wrapper.py
@@ -17,9 +17,9 @@ class DatasetWrapper(torch.utils.data.Dataset):
         features_subdir: str,
         index_column: str,
         target_column: Union[str, List[str]],
-        file_type: str,
         file_handler: AbstractFileHandler,
         df: pd.DataFrame,
+        file_type: str = None,
         transform: Optional[SmartCompose] = None,
         target_transform: Optional[AbstractTargetTransform] = None,
     ):
@@ -30,9 +30,12 @@ class DatasetWrapper(torch.utils.data.Dataset):
             features_subdir: Subdirectory containing the features.
             index_column: Index column of the dataframe.
             target_column: Target column of the dataframe.
-            file_type: File type of the features.
             file_handler: File handler to load the data.
             df: Dataframe containing the index and target column(s).
+            file_type: File type of the features. If `None`,
+                will not enforce a file_type. This can be useful
+                in case the dataset contains audio files
+                with different formats. Defualts to `None`.
             transform: Transform to apply to the features. Defaults to None.
             target_transform: Target transform to apply to the target.
                 Defaults to None.
@@ -54,7 +57,8 @@ class DatasetWrapper(torch.utils.data.Dataset):
 
     def _create_file_path(self, file: str) -> str:
         path = Path(self.path, self.features_subdir, file)
-        path = path.with_suffix(f".{self.file_type}")
+        if self.file_type is not None:
+            path = path.with_suffix(f".{self.file_type}")
         return str(path)
 
     def __len__(self) -> int:

--- a/autrainer/datasets/utils/dataset_wrapper.py
+++ b/autrainer/datasets/utils/dataset_wrapper.py
@@ -35,7 +35,7 @@ class DatasetWrapper(torch.utils.data.Dataset):
             file_type: File type of the features. If `None`,
                 will not enforce a file_type. This can be useful
                 in case the dataset contains audio files
-                with different formats. Defualts to `None`.
+                with different formats. Defaults to `None`.
             transform: Transform to apply to the features. Defaults to None.
             target_transform: Target transform to apply to the target.
                 Defaults to None.

--- a/autrainer/training/training.py
+++ b/autrainer/training/training.py
@@ -20,7 +20,7 @@ from autrainer.core.utils import (
     set_seed,
 )
 from autrainer.datasets import AbstractDataset
-from autrainer.datasets.utils import AbstractFileHandler
+from autrainer.datasets.utils import AbstractFileHandler, AudioFileHandler
 from autrainer.loggers import AbstractLogger
 from autrainer.models import AbstractModel
 from autrainer.transforms import SmartCompose, TransformManager
@@ -246,7 +246,7 @@ class ModularTaskTrainer:
         _preprocess_pipe = SmartCompose([])
         _file_handler = self.data.file_handler
         _features_subdir = cfg.dataset.get("features_subdir", "default")
-        if _features_subdir != "default":
+        if not isinstance(self.data.file_handler, AudioFileHandler):
             _preprocess = OmegaConf.to_container(
                 hydra.compose(f"preprocessing/{_features_subdir}")
             )["preprocessing"]

--- a/autrainer/training/training.py
+++ b/autrainer/training/training.py
@@ -246,7 +246,10 @@ class ModularTaskTrainer:
         _preprocess_pipe = SmartCompose([])
         _file_handler = self.data.file_handler
         _features_subdir = cfg.dataset.get("features_subdir", "default")
-        if not isinstance(self.data.file_handler, AudioFileHandler):
+        if (
+            not isinstance(self.data.file_handler, AudioFileHandler)
+            and _features_subdir != "default"
+        ):
             _preprocess = OmegaConf.to_container(
                 hydra.compose(f"preprocessing/{_features_subdir}")
             )["preprocessing"]

--- a/docs/source/modules/transforms.rst
+++ b/docs/source/modules/transforms.rst
@@ -29,7 +29,8 @@ Preprocessing Transforms
 ------------------------
 
 Preprocessing transforms are specified in the dataset configuration aligning the :attr:`features_subdir` with the name of the preprocessing file.
-This way, the processed data is stored in a subdirectory of the dataset directory with the same name as the preprocessing file.
+This way, the processed data is stored in a subdirectory of the dataset directory with the same name as the preprocessing file,
+or in a different path altogether by specifying the :attr:`features_path` attribute in the configuration file.
 To save the processed data, the :attr:`file_handler` specified in the dataset configuration is used.
 
 .. tip::
@@ -58,6 +59,14 @@ Preprocessing transforms consist of the following attributes:
    .. code-block:: python
 
       autrainer.cli.preprocess()
+
+.. warning::
+   Following `v0.6.0`, `autrainer` iterates over all files in all datasets
+   and extracts the respective features without replacement.
+   It is possible that features have been extracted for a subset of the dataset.
+   This may happen when different dataset subsets are supported.
+   Therefore, it is recommended that `autrainer preprocess` is always called before training.
+   Features have to be manually deleted to overwrite.
 
 `autrainer` offers default configurations for log-Mel spectrogram extraction and openSMILE feature extraction.
 

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -1,0 +1,201 @@
+import os
+from typing import List, Optional
+
+import audiofile
+import numpy as np
+import pandas as pd
+import pytest
+import torch
+
+from autrainer.core.scripts.preprocess_script import preprocess_main
+from autrainer.datasets import BaseClassificationDataset
+
+from .utils import BaseIndividualTempDir
+
+
+class TestBaseDatasets(BaseIndividualTempDir):
+    @staticmethod
+    def _mock_dataframes(
+        path: str,
+        index_column: str = "index",
+        target_column: str = "target",
+        file_type: str = "wav",
+        target_type: str = "classification",
+        num_files: int = 10,
+        output_files: Optional[List[str]] = None,
+    ) -> None:
+        assert target_type in [
+            "classification",
+            "ml-classification",
+            "regression",
+        ]
+        os.makedirs(os.path.join(path, "default"), exist_ok=True)
+        df = pd.DataFrame()
+        df[index_column] = [f"file{i}.{file_type}" for i in range(num_files)]
+        if target_type == "classification":
+            df[target_column] = [i % 10 for i in range(num_files)]
+        elif target_type == "regression":
+            df[target_column] = [i for i in range(num_files)]
+        else:
+            for i in range(10):
+                df[f"target_{i}"] = torch.randint(0, 2, (num_files,)).tolist()
+
+        output_files = output_files or ["train", "dev", "test"]
+        for output_file in output_files:
+            df.to_csv(os.path.join(path, f"{output_file}.csv"), index=False)
+
+    @staticmethod
+    def _mock_data(
+        path: str,
+        sampling_rate: int,
+        features_subdir: str = "default",
+        index_column: str = "index",
+        output_files: Optional[List[str]] = None,
+    ) -> None:
+        if output_files is None:
+            output_files = ["train", "dev", "test"]
+        dfs = [
+            pd.read_csv(os.path.join(path, f"{f}.csv")) for f in output_files
+        ]
+        for df in dfs:
+            for filename in df[index_column]:
+                audiofile.write(
+                    os.path.join(path, features_subdir, filename),
+                    np.random.rand(sampling_rate),
+                    sampling_rate,
+                )
+
+    @staticmethod
+    def _mock_dataset_kwargs() -> dict:
+        return {
+            "path": "data/TestDataset",
+            "features_subdir": "default",
+            "seed": 42,
+            "metrics": ["autrainer.metrics.Accuracy"],
+            "tracking_metric": "autrainer.metrics.Accuracy",
+            "index_column": "index",
+            "target_column": "target",
+            "file_type": "wav",
+            "file_handler": "autrainer.datasets.utils.AudioFileHandler",
+            "batch_size": 4,
+            "criterion": "autrainer.criterion.CrossEntropyLoss",
+            "transform": "wav",
+            "_target_": "autrainer.datasets.BaseClassificationDataset",
+        }
+
+    @pytest.mark.parametrize(
+        "preprocess,sampling_rate,features_path",
+        [
+            (
+                {
+                    "file_handler": {
+                        "autrainer.datasets.utils.AudioFileHandler": {
+                            "target_sample_rate": 16000
+                        }
+                    },
+                    "pipeline": [
+                        "autrainer.transforms.StereoToMono",
+                        {
+                            "autrainer.transforms.PannMel": {
+                                "sample_rate": 16000,
+                                "window_size": 512,
+                                "hop_size": 160,
+                                "mel_bins": 64,
+                                "fmin": 50,
+                                "fmax": 8000,
+                                "ref": 1.0,
+                                "amin": 1e-10,
+                                "top_db": None,
+                            }
+                        },
+                    ],
+                },
+                16000,
+                None,
+            ),
+            (
+                {
+                    "file_handler": {
+                        "autrainer.datasets.utils.AudioFileHandler": {
+                            "target_sample_rate": 16000
+                        }
+                    },
+                    "pipeline": [
+                        "autrainer.transforms.StereoToMono",
+                        {
+                            "autrainer.transforms.PannMel": {
+                                "sample_rate": 16000,
+                                "window_size": 512,
+                                "hop_size": 160,
+                                "mel_bins": 64,
+                                "fmin": 50,
+                                "fmax": 8000,
+                                "ref": 1.0,
+                                "amin": 1e-10,
+                                "top_db": None,
+                            }
+                        },
+                    ],
+                },
+                16000,
+                "foo",
+            ),
+        ],
+    )
+    def test_preprocessing(
+        self, preprocess, sampling_rate, features_path
+    ) -> None:
+        self._mock_dataframes("data/TestDataset")
+        self._mock_data("data/TestDataset", sampling_rate)
+
+        dataset_args = self._mock_dataset_kwargs()
+        criterion = dataset_args.pop("criterion")
+        transform = dataset_args.pop("transform")
+        target = dataset_args.pop("_target_")
+        data = BaseClassificationDataset(**dataset_args)
+        for d in (data.train_dataset, data.dev_dataset, data.test_dataset):
+            for x in d:
+                assert x[0].shape == (1, sampling_rate)
+
+        dataset_args["criterion"] = criterion
+        dataset_args["transform"] = transform
+        dataset_args["features_path"] = features_path
+        dataset_args["_target_"] = target
+        dataset_args["features_subdir"] = "log_mel_16k"
+        dataset_args["file_type"] = "npy"
+        dataset_args["file_handler"] = (
+            "autrainer.datasets.utils.NumpyFileHandler"
+        )
+
+        preprocess_main(
+            name="TestDataset",
+            dataset=dataset_args,
+            preprocess=preprocess,
+            num_workers=1,
+            update_frequency=1,
+        )
+
+        dataset_args.pop("_target_")
+        dataset_args.pop("_convert_")
+        dataset_args.pop("_recursive_")
+        dataset_args["features_path"] = features_path
+        dataset_args["file_type"] = "npy"
+        dataset_args["file_handler"] = (
+            "autrainer.datasets.utils.NumpyFileHandler"
+        )
+        dataset_args["features_subdir"] = "log_mel_16k"
+
+        data = BaseClassificationDataset(**dataset_args)
+        for d in (data.train_dataset, data.dev_dataset, data.test_dataset):
+            for x in d:
+                assert x[0].shape == (
+                    1,
+                    sampling_rate
+                    // preprocess["pipeline"][-1][
+                        "autrainer.transforms.PannMel"
+                    ]["hop_size"]
+                    + 1,
+                    preprocess["pipeline"][-1]["autrainer.transforms.PannMel"][
+                        "mel_bins"
+                    ],
+                )


### PR DESCRIPTION
@ramppdev this is a draft PR for changing the underlying dataset. I want your feedback on whether I'm on the right direction before finishing/debugging/testing.

Basically I have done two major changes:

1. Use `@cached_property` for `train_df`, `dev_df`, `test_df`, which defaults to the current structure, but can be overriden if the user doesn't want to change the original format. I also adapted the datasets already which *cannot* be downloaded automatically. For those that can, I have no problem with the original format.ee 

2. Change the `preprocess_script` to *instantiate* the dataset rather than load the CSVs manually, then rely on the `DatasetWrapper` and `torch.utils.data.DataLoader` interfaces for iterating through the data, extracting features, and storing the data

There's probably a few other things to change, but hopefully this would relax the restrictions we have on the "hard" dataset format and rely on the programmatic interface of `DatasetWrapper`..

So let me know what you think of this new format and whether I've messed up something greatly before I continue!