### PR TITLE
Fix: safe call to F1 MLC scores

### DIFF
--- a/autrainer/metrics/abstract_metric.py
+++ b/autrainer/metrics/abstract_metric.py
@@ -122,7 +122,23 @@ class AbstractMetric(ABC):
             True if the first score is better.
         """
 
-    def unitary(self, y_true, y_pred):
+    def unitary(self, y_true: np.ndarray, y_pred: np.ndarray) -> float:
+        """Unitary evaluation of metric.
+
+        Metric computed for each individual label
+        in the case of multilabel classification
+        or regression.
+
+        In the default case, computes the metric
+        in the same way as globally.
+
+        Args:
+            y_true: ground truth values.
+            y_pred: prediction values.
+
+        Returns:
+            The unitary score.
+        """
         return self.__call__(y_true, y_pred)
 
 

--- a/autrainer/metrics/abstract_metric.py
+++ b/autrainer/metrics/abstract_metric.py
@@ -122,6 +122,9 @@ class AbstractMetric(ABC):
             True if the first score is better.
         """
 
+    def unitary(self, y_true, y_pred):
+        return self.__call__(y_true, y_pred)
+
 
 class BaseAscendingMetric(AbstractMetric):
     def __init__(

--- a/autrainer/metrics/multi_label_classification.py
+++ b/autrainer/metrics/multi_label_classification.py
@@ -11,7 +11,7 @@ def _safe_f1_score(
     pos_label=1,
     average="binary",
     sample_weight=None,
-    zero_division="warn"
+    zero_division="warn",
 ):
     multilabel = True
     if (
@@ -29,7 +29,7 @@ def _safe_f1_score(
         pos_label=pos_label,
         average=average,
         sample_weight=sample_weight,
-        zero_division=zero_division
+        zero_division=zero_division,
     )
 
 

--- a/autrainer/metrics/multi_label_classification.py
+++ b/autrainer/metrics/multi_label_classification.py
@@ -3,6 +3,36 @@ import sklearn.metrics
 from .abstract_metric import BaseAscendingMetric
 
 
+def _safe_f1_score(
+    y_true,
+    y_pred,
+    *,
+    labels=None,
+    pos_label=1,
+    average="binary",
+    sample_weight=None,
+    zero_division="warn"
+):
+    multilabel = True
+    if (
+        (len(y_true.shape) == 1)
+        or (y_true.shape[0] == 1)
+        or (y_true.shape[1] == 1)
+    ):
+        multilabel = False
+    if average != "binary" and not multilabel:
+        average = "binary"
+    return sklearn.metrics.f1_score(
+        y_true=y_true,
+        y_pred=y_pred,
+        labels=labels,
+        pos_label=pos_label,
+        average=average,
+        sample_weight=sample_weight,
+        zero_division=zero_division
+    )
+
+
 class MLAccuracy(BaseAscendingMetric):
     def __init__(self):
         """Accuracy metric using `sklearn.metrics.accuracy_score`."""
@@ -14,7 +44,7 @@ class MLF1Macro(BaseAscendingMetric):
         """F1 macro metric using `sklearn.metrics.f1_score`."""
         super().__init__(
             name="ml-f1-macro",
-            fn=sklearn.metrics.f1_score,
+            fn=_safe_f1_score,
             average="macro",
         )
 
@@ -24,7 +54,7 @@ class MLF1Micro(BaseAscendingMetric):
         """F1 micro metric using `sklearn.metrics.f1_score`."""
         super().__init__(
             name="ml-f1-micro",
-            fn=sklearn.metrics.f1_score,
+            fn=_safe_f1_score,
             average="micro",
         )
 
@@ -34,6 +64,6 @@ class MLF1Weighted(BaseAscendingMetric):
         """F1 weighted metric using `sklearn.metrics.f1_score`."""
         super().__init__(
             name="ml-f1-weighted",
-            fn=sklearn.metrics.f1_score,
+            fn=_safe_f1_score,
             average="weighted",
         )

--- a/autrainer/metrics/multi_label_classification.py
+++ b/autrainer/metrics/multi_label_classification.py
@@ -1,3 +1,4 @@
+import numpy as np
 import sklearn.metrics
 
 from .abstract_metric import BaseAscendingMetric
@@ -18,7 +19,19 @@ class MLF1Macro(BaseAscendingMetric):
             average="macro",
         )
 
-    def unitary(self, y_true, y_pred):
+    def unitary(self, y_true: np.ndarray, y_pred: np.ndarray) -> float:
+        """Unitary evaluation of metric.
+
+        Metric computed with `average='binary'`
+        i.e. only accounting for positive label.
+
+        Args:
+            y_true: ground truth values.
+            y_pred: prediction values.
+
+        Returns:
+            The unitary score.
+        """
         return float(
             sklearn.metrics.f1_score(
                 y_true=y_true, y_pred=y_pred, average="binary"
@@ -35,7 +48,19 @@ class MLF1Micro(BaseAscendingMetric):
             average="micro",
         )
 
-    def unitary(self, y_true, y_pred):
+    def unitary(self, y_true: np.ndarray, y_pred: np.ndarray) -> float:
+        """Unitary evaluation of metric.
+
+        Metric computed with `average='binary'`
+        i.e. only accounting for positive label.
+
+        Args:
+            y_true: ground truth values.
+            y_pred: prediction values.
+
+        Returns:
+            The unitary score.
+        """
         return float(
             sklearn.metrics.f1_score(
                 y_true=y_true, y_pred=y_pred, average="binary"
@@ -52,7 +77,19 @@ class MLF1Weighted(BaseAscendingMetric):
             average="weighted",
         )
 
-    def unitary(self, y_true, y_pred):
+    def unitary(self, y_true: np.ndarray, y_pred: np.ndarray) -> float:
+        """Unitary evaluation of metric.
+
+        Metric computed with `average='binary'`
+        i.e. only accounting for positive label.
+
+        Args:
+            y_true: ground truth values.
+            y_pred: prediction values.
+
+        Returns:
+            The unitary score.
+        """
         return float(
             sklearn.metrics.f1_score(
                 y_true=y_true, y_pred=y_pred, average="binary"

--- a/autrainer/metrics/multi_label_classification.py
+++ b/autrainer/metrics/multi_label_classification.py
@@ -23,7 +23,7 @@ class MLF1Macro(BaseAscendingMetric):
         """Unitary evaluation of metric.
 
         Metric computed with `average='binary'`
-        i.e. only accounting for positive label.
+        i.e. only accounting for the positive label.
 
         Args:
             y_true: ground truth values.
@@ -52,7 +52,7 @@ class MLF1Micro(BaseAscendingMetric):
         """Unitary evaluation of metric.
 
         Metric computed with `average='binary'`
-        i.e. only accounting for positive label.
+        i.e. only accounting for the positive label.
 
         Args:
             y_true: ground truth values.
@@ -81,7 +81,7 @@ class MLF1Weighted(BaseAscendingMetric):
         """Unitary evaluation of metric.
 
         Metric computed with `average='binary'`
-        i.e. only accounting for positive label.
+        i.e. only accounting for the positive label.
 
         Args:
             y_true: ground truth values.

--- a/autrainer/metrics/multi_label_classification.py
+++ b/autrainer/metrics/multi_label_classification.py
@@ -3,36 +3,6 @@ import sklearn.metrics
 from .abstract_metric import BaseAscendingMetric
 
 
-def _safe_f1_score(
-    y_true,
-    y_pred,
-    *,
-    labels=None,
-    pos_label=1,
-    average="binary",
-    sample_weight=None,
-    zero_division="warn",
-):
-    multilabel = True
-    if (
-        (len(y_true.shape) == 1)
-        or (y_true.shape[0] == 1)
-        or (y_true.shape[1] == 1)
-    ):
-        multilabel = False
-    if average != "binary" and not multilabel:
-        average = "binary"
-    return sklearn.metrics.f1_score(
-        y_true=y_true,
-        y_pred=y_pred,
-        labels=labels,
-        pos_label=pos_label,
-        average=average,
-        sample_weight=sample_weight,
-        zero_division=zero_division,
-    )
-
-
 class MLAccuracy(BaseAscendingMetric):
     def __init__(self):
         """Accuracy metric using `sklearn.metrics.accuracy_score`."""
@@ -44,8 +14,15 @@ class MLF1Macro(BaseAscendingMetric):
         """F1 macro metric using `sklearn.metrics.f1_score`."""
         super().__init__(
             name="ml-f1-macro",
-            fn=_safe_f1_score,
+            fn=sklearn.metrics.f1_score,
             average="macro",
+        )
+
+    def unitary(self, y_true, y_pred):
+        return float(
+            sklearn.metrics.f1_score(
+                y_true=y_true, y_pred=y_pred, average="binary"
+            )
         )
 
 
@@ -54,8 +31,15 @@ class MLF1Micro(BaseAscendingMetric):
         """F1 micro metric using `sklearn.metrics.f1_score`."""
         super().__init__(
             name="ml-f1-micro",
-            fn=_safe_f1_score,
+            fn=sklearn.metrics.f1_score,
             average="micro",
+        )
+
+    def unitary(self, y_true, y_pred):
+        return float(
+            sklearn.metrics.f1_score(
+                y_true=y_true, y_pred=y_pred, average="binary"
+            )
         )
 
 
@@ -64,6 +48,13 @@ class MLF1Weighted(BaseAscendingMetric):
         """F1 weighted metric using `sklearn.metrics.f1_score`."""
         super().__init__(
             name="ml-f1-weighted",
-            fn=_safe_f1_score,
+            fn=sklearn.metrics.f1_score,
             average="weighted",
+        )
+
+    def unitary(self, y_true, y_pred):
+        return float(
+            sklearn.metrics.f1_score(
+                y_true=y_true, y_pred=y_pred, average="binary"
+            )
         )

--- a/autrainer/training/outputs_tracker.py
+++ b/autrainer/training/outputs_tracker.py
@@ -126,7 +126,7 @@ class OutputsTracker:
     @property
     @check_saved
     def predictions(self) -> np.ndarray:
-        return self._predictions
+        return np.array(self._predictions)
 
     @property
     @check_saved

--- a/autrainer/training/training.py
+++ b/autrainer/training/training.py
@@ -1,5 +1,4 @@
 from copy import deepcopy
-import numpy as np
 import os
 from pathlib import Path
 from typing import Callable, Dict, List, Tuple
@@ -801,8 +800,6 @@ class ModularTaskTrainer:
         TODO: Need to define schema in the docs.
 
         """
-        targets = tracker.targets
-        predictions = np.array(tracker.predictions)
         results = {m.name: {} for m in self.data.metrics}
         for metric in self.data.metrics:
             if isinstance(self.data.target_column, list):
@@ -811,10 +808,10 @@ class ModularTaskTrainer:
                 # loops over all targets and computes the metric for them
                 for idx, col in enumerate(self.data.target_column):
                     results[metric.name][col] = metric(
-                            targets[:, idx],
-                            predictions[:, idx],
+                            tracker.targets[:, idx],
+                            tracker.predictions[:, idx],
                         )
-            results[metric.name]["all"] = metric(targets, predictions)
+            results[metric.name]["all"] = metric(tracker.targets, tracker.predictions)
             for s in stratify:
                 if not isinstance(self.data.target_column, list):
                     raise ValueError(
@@ -824,8 +821,8 @@ class ModularTaskTrainer:
                 for v in groundtruth[s].unique():
                     idx = groundtruth.loc[groundtruth[s] == v].index
                     results[metric.name][v] = metric(
-                            targets[idx],
-                            predictions[idx],
+                            tracker.targets[idx],
+                            tracker.predictions[idx],
                         )
         return results
 

--- a/autrainer/training/training.py
+++ b/autrainer/training/training.py
@@ -808,10 +808,12 @@ class ModularTaskTrainer:
                 # loops over all targets and computes the metric for them
                 for idx, col in enumerate(self.data.target_column):
                     results[metric.name][col] = metric(
-                            tracker.targets[:, idx],
-                            tracker.predictions[:, idx],
-                        )
-            results[metric.name]["all"] = metric(tracker.targets, tracker.predictions)
+                        tracker.targets[:, idx],
+                        tracker.predictions[:, idx],
+                    )
+            results[metric.name]["all"] = metric(
+                tracker.targets, tracker.predictions
+            )
             for s in stratify:
                 if not isinstance(self.data.target_column, list):
                     raise ValueError(
@@ -821,9 +823,9 @@ class ModularTaskTrainer:
                 for v in groundtruth[s].unique():
                     idx = groundtruth.loc[groundtruth[s] == v].index
                     results[metric.name][v] = metric(
-                            tracker.targets[idx],
-                            tracker.predictions[idx],
-                        )
+                        tracker.targets[idx],
+                        tracker.predictions[idx],
+                    )
         return results
 
     @property

--- a/autrainer/training/training.py
+++ b/autrainer/training/training.py
@@ -822,9 +822,14 @@ class ModularTaskTrainer:
                     )
                 for v in groundtruth[s].unique():
                     idx = groundtruth.loc[groundtruth[s] == v].index
+                    # Map groundtruth indices to tracker indices
+                    # This accounts for random shuffling
+                    indices = [
+                        i for i, x in enumerate(tracker.indices) if x in idx
+                    ]
                     results[metric.name][v] = metric(
-                        tracker.targets[idx],
-                        tracker.predictions[idx],
+                        tracker.targets[indices],
+                        tracker.predictions[indices],
                     )
         return results
 

--- a/autrainer/training/training.py
+++ b/autrainer/training/training.py
@@ -27,7 +27,7 @@ from autrainer.transforms import SmartCompose, TransformManager
 
 from .callback_manager import CallbackManager
 from .continue_training import ContinueTraining
-from .outputs_tracker import init_trackers
+from .outputs_tracker import OutputsTracker, init_trackers
 from .utils import (
     format_results,
     load_pretrained_model_state,
@@ -790,14 +790,28 @@ class ModularTaskTrainer:
             results[metric.name] = metric(tracker.targets, tracker.predictions)
         return results
 
-    def _disaggregated_evaluation(self, tracker, groundtruth, stratify):
+    def _disaggregated_evaluation(
+        self,
+        tracker: OutputsTracker,
+        groundtruth: pd.DataFrame,
+        stratify: List[str] = None,
+    ) -> Dict:
         r"""Runs evaluation, optionally disaggregated.
 
-        Loops over all metrics, and computes them for dataframe.
-        Allows stratification over a specific variable.
-        Also handles multi-label processing.
-        Returns a dictionary containing all metrics.
-        TODO: Need to define schema in the docs.
+        Computes each metric globally (over all targets)
+        and unitary (over each target).
+        Additionally supports disaggregated evaluations
+        for different values
+        of columns present in the data dataframe.
+
+        Args:
+            tracker: outputs tracker over which to compute metric.
+            groundruth: dataframe with groundtruth data and metadata.
+            stratify: optional list of metadata to run evaluation
+                in stratified manner.
+
+        Returns:
+            Dictionary containing results
 
         """
         results = {m.name: {} for m in self.data.metrics}

--- a/autrainer/training/training.py
+++ b/autrainer/training/training.py
@@ -807,7 +807,7 @@ class ModularTaskTrainer:
                 # multi-target regression
                 # loops over all targets and computes the metric for them
                 for idx, col in enumerate(self.data.target_column):
-                    results[metric.name][col] = metric(
+                    results[metric.name][col] = metric.unitary(
                         tracker.targets[:, idx],
                         tracker.predictions[:, idx],
                     )

--- a/autrainer/training/utils.py
+++ b/autrainer/training/utils.py
@@ -58,10 +58,10 @@ def disaggregated_evaluation(
                 idx = groundtruth.loc[groundtruth[s] == v].index
                 # Map groundtruth indices to tracker indices
                 # This accounts for random shuffling
-                indices = [i for i, x in enumerate(indices) if x in idx]
+                mapped_indices = [i for i, x in enumerate(indices) if x in idx]
                 results[metric.name][v] = metric(
-                    targets[indices],
-                    predictions[indices],
+                    targets[mapped_indices],
+                    predictions[mapped_indices],
                 )
     return results
 

--- a/autrainer/training/utils.py
+++ b/autrainer/training/utils.py
@@ -27,8 +27,12 @@ def disaggregated_evaluation(
     of columns present in the data dataframe.
 
     Args:
-        tracker: outputs tracker over which to compute metric.
+        targets: array with groundtruth values.
+        predictions: array with model predictions.
+        indices: array tracking initial dataset indices.
         groundruth: dataframe with groundtruth data and metadata.
+        metrics: list of metrics to use for evaluation.
+        target_column: columns to evaluate on.
         stratify: optional list of metadata to run evaluation
             in stratified manner.
 

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -158,6 +158,6 @@ class TestAllMetrics:
         self._test_result(m, truth, pred, res)
         for idx in range(truth.shape[1]):
             np.testing.assert_almost_equal(
-                m(truth[:, idx], pred[:, idx]),
+                m.unitary(truth[:, idx], pred[:, idx]),
                 f1_score(truth[:, idx], pred[:, idx]),
             )

--- a/tests/test_metrics.py
+++ b/tests/test_metrics.py
@@ -1,9 +1,11 @@
 import logging
-from typing import Type
+from typing import List, Type
 
 import numpy as np
+import numpy.testing
 import pandas as pd
 import pytest
+from sklearn.metrics import f1_score
 
 from autrainer.metrics import (
     CCC,
@@ -53,6 +55,11 @@ class TestAllMetrics:
                 assert m.get_best(x) == 1, "1 should be the best."
                 assert m.get_best_pos(x) == 0, "1 should be at position 0."
 
+    def _test_result(
+        self, m: AbstractMetric, truth: List, pred: List, res: float
+    ) -> None:
+        np.testing.assert_almost_equal(m(truth, pred), res, 2)
+
     @pytest.mark.parametrize("cls", [Accuracy, F1, UAR, CCC, MAE, MSE, PCC])
     def test_classification_regression_metrics(
         self, cls: Type[AbstractMetric]
@@ -63,12 +70,82 @@ class TestAllMetrics:
         self._test_comparisons(cls())
 
     @pytest.mark.parametrize(
-        "cls",
-        [MLAccuracy, MLF1Macro, MLF1Micro, MLF1Weighted],
+        "cls,truth,pred,res",
+        [
+            (
+                MLAccuracy,
+                np.array([[0, 1], [1, 1]]),
+                np.array([[0, 1], [1, 1]]),
+                1,
+            ),
+            (
+                MLAccuracy,
+                np.array([[0, 1], [1, 1]]),
+                np.array([[1, 0], [0, 0]]),
+                0,
+            ),
+            (
+                MLF1Macro,
+                np.array([[0, 1], [1, 1]]),
+                np.array([[0, 1], [1, 1]]),
+                1,
+            ),
+            (
+                MLF1Macro,
+                np.array([[0, 1], [1, 1]]),
+                np.array([[1, 0], [0, 0]]),
+                0,
+            ),
+            (
+                MLF1Macro,
+                np.array([[0, 1, 1], [1, 1, 1], [0, 0, 1]]),
+                np.array([[1, 0, 1], [0, 1, 1], [0, 0, 1]]),
+                0.55,
+            ),
+            (
+                MLF1Micro,
+                np.array([[0, 1], [1, 1]]),
+                np.array([[0, 1], [1, 1]]),
+                1,
+            ),
+            (
+                MLF1Micro,
+                np.array([[0, 1], [1, 1]]),
+                np.array([[1, 0], [0, 0]]),
+                0,
+            ),
+            (
+                MLF1Micro,
+                np.array([[0, 1, 1], [1, 1, 1], [0, 0, 1]]),
+                np.array([[1, 0, 1], [0, 1, 1], [0, 0, 1]]),
+                0.73,
+            ),
+            (
+                MLF1Weighted,
+                np.array([[0, 1], [1, 1]]),
+                np.array([[0, 1], [1, 1]]),
+                1,
+            ),
+            (
+                MLF1Weighted,
+                np.array([[0, 1], [1, 1]]),
+                np.array([[1, 0], [0, 0]]),
+                0,
+            ),
+            (
+                MLF1Micro,
+                np.array([[0, 1, 1], [1, 1, 1], [0, 0, 1]]),
+                np.array([[1, 0, 1], [0, 1, 1], [0, 0, 1]]),
+                0.72,
+            ),
+        ],
     )
     def test_mlc_metrics(
         self,
         cls: Type[AbstractMetric],
+        truth: np.ndarray,
+        pred: np.ndarray,
+        res: float,
         caplog: pytest.LogCaptureFixture,
     ) -> None:
         self._test_metric(cls())
@@ -77,3 +154,10 @@ class TestAllMetrics:
         assert "Error computing" in caplog.text, "Warning should be logged."
         self._test_starting_metric(cls())
         self._test_comparisons(cls())
+        m = cls()
+        self._test_result(m, truth, pred, res)
+        for idx in range(truth.shape[1]):
+            np.testing.assert_almost_equal(
+                m(truth[:, idx], pred[:, idx]),
+                f1_score(truth[:, idx], pred[:, idx]),
+            )


### PR DESCRIPTION
This closes #57 by introducing a `_safe_f1_score` function that checks for the dimensionality of predictions/labels and overrides the `average` argument if necessary..

When testing this with `ToyTabular-MLC` this resulted in the results being stored in `test_holistic.yaml` being identical to the ones printed at the end of training.

Nevertheless, I want to add some proper tests before merging