### PR TITLE
Added simple dataset overview to bookkeeping

### DIFF
--- a/autrainer/core/utils/bookkeeping.py
+++ b/autrainer/core/utils/bookkeeping.py
@@ -101,6 +101,76 @@ class Bookkeeping:
             exist_ok=True,
         )
 
+    def save_dataset_summary(
+        self,
+        data: "AbstractDataset",
+        filename: str,
+        val_exists: bool = False,
+    ) -> None:
+        """Save some overview of the dataset to a file.
+
+        Args:
+            data: dataset object
+            filename: Name of the file to save the overview to.
+        """
+        if val_exists:
+            split_datasets = [data.train_dataset, data.val_dataset, data.test_dataset]
+            index = ["Train", "Development", "Test", "Total"]
+        else:
+            split_datasets = [data.train_dataset, data.test_dataset]
+            index = ["Train", "Test", "Total"]
+        n_samples = []
+        if isinstance(data, BaseClassificationDataset) or isinstance(data, BaseMLClassificationDataset):
+            n_classes = []
+            n_majority_class = []
+            n_minority_class = []
+            class_imbalance = []
+        elif isinstance(data, BaseRegressionDataset):
+            mean_label = []
+            std_label = []
+            max_value = []
+            min_value = []
+        
+        data_dfs = [dataset.df for dataset in split_datasets]
+        aggregated_data_df = pd.concat(data_dfs, axis=0, ignore_index=True)
+        data_dfs.append(aggregated_data_df)
+        target_column = split_datasets[0].target_column
+        for data_df in data_dfs:
+            n_samples.append(data_df.shape[0])
+            if isinstance(data, BaseClassificationDataset):
+                label_counts = data_df[target_column].value_counts()
+                n_classes.append(label_counts.count())
+                n_majority_class.append(label_counts.max())
+                n_minority_class.append(label_counts.min())
+                class_imbalance.append(label_counts.max() / label_counts.min())
+            elif isinstance(data, BaseMLClassificationDataset):
+                label_counts = data_df[target_column].sum(axis=0)
+                n_classes.append(len(target_column))
+                n_majority_class.append(label_counts.max())
+                n_minority_class.append(label_counts.min())
+                class_imbalance.append(label_counts.max() / label_counts.min())
+            elif isinstance(data, BaseRegressionDataset):
+                label_values = data_df[target_column].values
+                mean_label.append(label_values.mean())
+                std_label.append(label_values.std())
+                max_value.append(label_values.max())
+                min_value.append(label_values.min())
+        if isinstance(data, BaseClassificationDataset) or isinstance(data, BaseMLClassificationDataset):
+            data_overview_df = pd.DataFrame(
+                {"n_samples": n_samples, "n_classes": n_classes, "n_majority_class": n_majority_class, 
+                "n_minority_class": n_minority_class, "imbalance_ratio": class_imbalance},
+                index=index) 
+        elif isinstance(data, BaseRegressionDataset):
+            data_overview_df = pd.DataFrame(
+                {"n_samples": n_samples, "mean_label": mean_label, "std_label": std_label, 
+                "max_value": max_value, "min_value": min_value},
+                index=index)
+        else:
+            data_overview_df = pd.DataFrame(
+                {"n_samples": n_samples},
+                index=index)
+        data_overview_df.to_csv(os.path.join(self.output_directory, filename))
+
     def save_model_summary(
         self,
         model: torch.nn.Module,

--- a/autrainer/training/training.py
+++ b/autrainer/training/training.py
@@ -154,6 +154,9 @@ class ModularTaskTrainer:
                 state_dict,
                 skip_last_layer,
             )
+        self.bookkeeping.save_dataset_summary(
+            self.data, "dataset_summary.csv"
+        )
         self.bookkeeping.save_model_summary(
             self.model, self.train_dataset, "model_summary.txt"
         )


### PR DESCRIPTION
This PR would add some simple dataset overview of info that seem IMO relevant info for any given task. For classification and ML classification it determines the number of classes, as well as size of max/min class + data imbalance. For regression it calculates mean, std min and max for the given label. Total number of samples is always calculated. In this version it also shouldn't break with new task types like SSL #64 or multi-label regression, but could/should potentially be extended for these.

For the moment, I did not know how to best deal with the validation set. Sometimes there is no dataset available, sometimes it is just the test dataset, so the default is to just save it for train and test. 

Also, these were just the info points that come "for free", what might be interesting information to extend to would be e.g., total audio length for audio files or image sizes for image data etc., but for that we might need to load each data point once already in the bookkeeping.