### PR TITLE
Skip and Disable Training Results Tracking if Outputs are not Saved

### DIFF
--- a/autrainer/training/outputs_tracker.py
+++ b/autrainer/training/outputs_tracker.py
@@ -140,7 +140,7 @@ def init_trackers(
     data: AbstractDataset,
     criterion: DictConfig,
     bookkeeping: Bookkeeping = None,
-) -> OutputsTracker:
+) -> List[OutputsTracker]:
     trackers = []
     for export, prefix in zip(exports, prefixes):
         trackers.append(

--- a/autrainer/training/training.py
+++ b/autrainer/training/training.py
@@ -347,7 +347,7 @@ class ModularTaskTrainer:
                 data=self.data,
                 criterion=self.criterion,
                 bookkeeping=self.bookkeeping,
-            )
+            )[0]
         else:
             self.train_tracker = None
 


### PR DESCRIPTION
This closes #62 by just skipping the initialization of `self.train_tracker` when the results are not exported.