### PR TITLE
Fix openSMILE Feature Extraction Transform Output Shape

### DIFF
--- a/autrainer/transforms/specific_transforms.py
+++ b/autrainer/transforms/specific_transforms.py
@@ -602,4 +602,4 @@ class OpenSMILE(AbstractTransform):
 
     def __call__(self, data: torch.Tensor) -> torch.Tensor:
         data = self.smile.process_signal(data.numpy(), self.sample_rate)
-        return torch.from_numpy(self.smile.to_numpy(data))
+        return torch.from_numpy(self.smile.to_numpy(data)).squeeze()

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -327,9 +327,9 @@ class TestOpenSMILE:
         "feature_set, functionals, expected",
         [
             ("ComParE_2016", False, (65, 96)),
-            ("ComParE_2016", True, (6373, 1)),
+            ("ComParE_2016", True, (6373,)),
             ("eGeMAPSv02", False, (25, 96)),
-            ("eGeMAPSv02", True, (88, 1)),
+            ("eGeMAPSv02", True, (88,)),
         ],
     )
     def test_opensmile(
@@ -342,7 +342,7 @@ class TestOpenSMILE:
         y = OpenSMILE(feature_set, 16000, functionals=functionals)(x)
         assert torch.is_tensor(y), "Output should be a tensor"
         assert y.shape == torch.Size(
-            (1,) + expected
+            expected
         ), "Output shape should match the expected shape"
         assert y.dtype == torch.float32, "Output should be float32"
 


### PR DESCRIPTION
This closes https://github.com/autrainer/autrainer/issues/72 by squeezing the dimensions of the openSMILE feature extraction transform output, as there are unexpected dimensions.