### PR TITLE
Fix Multi-Target Regression Typo and Add Missing MTR Tests

### DIFF
--- a/autrainer/datasets/abstract_dataset.py
+++ b/autrainer/datasets/abstract_dataset.py
@@ -669,7 +669,7 @@ class BaseMTRegressionDataset(AbstractDataset):
     @cached_property
     def target_transform(self) -> MultiTargetMinMaxScaler:
         return MultiTargetMinMaxScaler(
-            targets=self.target_column,
+            target=self.target_column,
             minimum=self.df_train[self.target_column].min().to_list(),
             maximum=self.df_train[self.target_column].max().to_list(),
         )


### PR DESCRIPTION
Closes #59 by adding the missing test for the `BaseMTRegressionDataset` class.

Also, while implementing i noticed a small typo bug in the target transform.