### PR TITLE
Fix Order of Batch Size and Inference Batch Size Dataset Arguments

### DIFF
--- a/autrainer/datasets/abstract_dataset.py
+++ b/autrainer/datasets/abstract_dataset.py
@@ -41,8 +41,8 @@ class AbstractDataset(ABC):
         file_type: str,
         file_handler: Union[str, DictConfig, Dict],
         batch_size: int,
-        features_path: Optional[str] = None,
         inference_batch_size: Optional[int] = None,
+        features_path: Optional[str] = None,
         train_transform: Optional[SmartCompose] = None,
         dev_transform: Optional[SmartCompose] = None,
         test_transform: Optional[SmartCompose] = None,
@@ -66,12 +66,12 @@ class AbstractDataset(ABC):
             file_type: File type of the features.
             file_handler: File handler to load the data.
             batch_size: Batch size.
+            inference_batch_size: Inference batch size. If None, defaults to
+                batch_size. Defaults to None.
             features_path: Root path to features. Useful
                 when features need to be extracted and stored
                 in a different folder than the root of the dataset.
                 If `None`, will be set to `path`. Defaults to `None`.
-            inference_batch_size: Inference batch size. If None, defaults to
-                batch_size. Defaults to None.
             train_transform: Transform to apply to the training set.
                 Defaults to None.
             dev_transform: Transform to apply to the development set.
@@ -364,12 +364,12 @@ class BaseClassificationDataset(AbstractDataset):
             file_type: File type of the features.
             file_handler: File handler to load the data.
             batch_size: Batch size.
+            inference_batch_size: Inference batch size. If None, defaults to
+                batch_size. Defaults to None.
             features_path: Root path to features. Useful
                 when features need to be extracted and stored
                 in a different folder than the root of the dataset.
                 If `None`, will be set to `path`. Defaults to `None`.
-            inference_batch_size: Inference batch size. If None, defaults to
-                batch_size. Defaults to None.
             train_transform: Transform to apply to the training set.
                 Defaults to None.
             dev_transform: Transform to apply to the development set.
@@ -428,8 +428,8 @@ class BaseMLClassificationDataset(AbstractDataset):
         file_type: str,
         file_handler: Union[str, DictConfig, Dict],
         batch_size: int,
-        features_path: Optional[str] = None,
         inference_batch_size: Optional[int] = None,
+        features_path: Optional[str] = None,
         train_transform: Optional[SmartCompose] = None,
         dev_transform: Optional[SmartCompose] = None,
         test_transform: Optional[SmartCompose] = None,
@@ -452,12 +452,12 @@ class BaseMLClassificationDataset(AbstractDataset):
             file_type: File type of the features.
             file_handler: File handler to load the data.
             batch_size: Batch size.
+            inference_batch_size: Inference batch size. If None, defaults to
+                batch_size. Defaults to None.
             features_path: Root path to features. Useful
                 when features need to be extracted and stored
                 in a different folder than the root of the dataset.
                 If `None`, will be set to `path`. Defaults to `None`.
-            inference_batch_size: Inference batch size. If None, defaults to
-                batch_size. Defaults to None.
             train_transform: Transform to apply to the training set.
                 Defaults to None.
             dev_transform: Transform to apply to the development set.
@@ -481,8 +481,8 @@ class BaseMLClassificationDataset(AbstractDataset):
             file_type=file_type,
             file_handler=file_handler,
             batch_size=batch_size,
-            features_path=features_path,
             inference_batch_size=inference_batch_size,
+            features_path=features_path,
             train_transform=train_transform,
             dev_transform=dev_transform,
             test_transform=test_transform,
@@ -530,8 +530,8 @@ class BaseRegressionDataset(AbstractDataset):
         file_type: str,
         file_handler: Union[str, DictConfig, Dict],
         batch_size: int,
-        features_path: Optional[str] = None,
         inference_batch_size: Optional[int] = None,
+        features_path: Optional[str] = None,
         train_transform: Optional[SmartCompose] = None,
         dev_transform: Optional[SmartCompose] = None,
         test_transform: Optional[SmartCompose] = None,
@@ -553,12 +553,12 @@ class BaseRegressionDataset(AbstractDataset):
             file_type: File type of the features.
             file_handler: File handler to load the data.
             batch_size: Batch size.
+            inference_batch_size: Inference batch size. If None, defaults to
+                batch_size. Defaults to None.
             features_path: Root path to features. Useful
                 when features need to be extracted and stored
                 in a different folder than the root of the dataset.
                 If `None`, will be set to `path`. Defaults to `None`.
-            inference_batch_size: Inference batch size. If None, defaults to
-                batch_size. Defaults to None.
             train_transform: Transform to apply to the training set.
                 Defaults to None.
             dev_transform: Transform to apply to the development set.
@@ -579,8 +579,8 @@ class BaseRegressionDataset(AbstractDataset):
             file_type=file_type,
             file_handler=file_handler,
             batch_size=batch_size,
-            features_path=features_path,
             inference_batch_size=inference_batch_size,
+            features_path=features_path,
             train_transform=train_transform,
             dev_transform=dev_transform,
             test_transform=test_transform,
@@ -609,8 +609,8 @@ class BaseMTRegressionDataset(AbstractDataset):
         file_type: str,
         file_handler: Union[str, DictConfig, Dict],
         batch_size: int,
-        features_path: Optional[str] = None,
         inference_batch_size: Optional[int] = None,
+        features_path: Optional[str] = None,
         train_transform: Optional[SmartCompose] = None,
         dev_transform: Optional[SmartCompose] = None,
         test_transform: Optional[SmartCompose] = None,
@@ -632,12 +632,12 @@ class BaseMTRegressionDataset(AbstractDataset):
             file_type: File type of the features.
             file_handler: File handler to load the data.
             batch_size: Batch size.
+            inference_batch_size: Inference batch size. If None, defaults to
+                batch_size. Defaults to None.
             features_path: Root path to features. Useful
                 when features need to be extracted and stored
                 in a different folder than the root of the dataset.
                 If `None`, will be set to `path`. Defaults to `None`.
-            inference_batch_size: Inference batch size. If None, defaults to
-                batch_size. Defaults to None.
             train_transform: Transform to apply to the training set.
                 Defaults to None.
             dev_transform: Transform to apply to the development set.
@@ -658,8 +658,8 @@ class BaseMTRegressionDataset(AbstractDataset):
             file_type=file_type,
             file_handler=file_handler,
             batch_size=batch_size,
-            features_path=features_path,
             inference_batch_size=inference_batch_size,
+            features_path=features_path,
             train_transform=train_transform,
             dev_transform=dev_transform,
             test_transform=test_transform,

--- a/autrainer/datasets/aibo.py
+++ b/autrainer/datasets/aibo.py
@@ -42,8 +42,8 @@ class AIBO(BaseClassificationDataset):
         file_type: str,
         file_handler: Union[str, DictConfig, Dict],
         batch_size: int,
-        features_path: Optional[str] = None,
         inference_batch_size: Optional[int] = None,
+        features_path: Optional[str] = None,
         train_transform: Optional[SmartCompose] = None,
         dev_transform: Optional[SmartCompose] = None,
         test_transform: Optional[SmartCompose] = None,
@@ -67,12 +67,12 @@ class AIBO(BaseClassificationDataset):
             file_type: File type of the features.
             file_handler: File handler to load the data.
             batch_size: Batch size.
+            inference_batch_size: Inference batch size. If None, defaults to
+                batch_size. Defaults to None.
             features_path: Root path to features. Useful
                 when features need to be extracted and stored
                 in a different folder than the root of the dataset.
                 If `None`, will be set to `path`. Defaults to `None`.
-            inference_batch_size: Inference batch size. If None, defaults to
-                batch_size. Defaults to None.
             train_transform: Transform to apply to the training set.
                 Defaults to None.
             dev_transform: Transform to apply to the development set.
@@ -96,8 +96,8 @@ class AIBO(BaseClassificationDataset):
             file_type=file_type,
             file_handler=file_handler,
             batch_size=batch_size,
-            features_path=features_path,
             inference_batch_size=inference_batch_size,
+            features_path=features_path,
             train_transform=train_transform,
             dev_transform=dev_transform,
             test_transform=test_transform,

--- a/autrainer/datasets/dcase_2016_t1.py
+++ b/autrainer/datasets/dcase_2016_t1.py
@@ -46,8 +46,8 @@ class DCASE2016Task1(BaseClassificationDataset):
         file_type: str,
         file_handler: Union[str, DictConfig, Dict],
         batch_size: int,
-        features_path: Optional[str] = None,
         inference_batch_size: Optional[int] = None,
+        features_path: Optional[str] = None,
         train_transform: Optional[SmartCompose] = None,
         dev_transform: Optional[SmartCompose] = None,
         test_transform: Optional[SmartCompose] = None,
@@ -70,12 +70,12 @@ class DCASE2016Task1(BaseClassificationDataset):
             file_type: File type of the features.
             file_handler: File handler to load the data.
             batch_size: Batch size.
+            inference_batch_size: Inference batch size. If None, defaults to
+                batch_size. Defaults to None.
             features_path: Root path to features. Useful
                 when features need to be extracted and stored
                 in a different folder than the root of the dataset.
                 If `None`, will be set to `path`. Defaults to `None`.
-            inference_batch_size: Inference batch size. If None, defaults to
-                batch_size. Defaults to None.
             train_transform: Transform to apply to the training set.
                 Defaults to None.
             dev_transform: Transform to apply to the development set.
@@ -98,8 +98,8 @@ class DCASE2016Task1(BaseClassificationDataset):
             file_type=file_type,
             file_handler=file_handler,
             batch_size=batch_size,
-            features_path=features_path,
             inference_batch_size=inference_batch_size,
+            features_path=features_path,
             train_transform=train_transform,
             dev_transform=dev_transform,
             test_transform=test_transform,

--- a/autrainer/datasets/dcase_2018_t3.py
+++ b/autrainer/datasets/dcase_2018_t3.py
@@ -35,8 +35,8 @@ class DCASE2018Task3(BaseClassificationDataset):
         file_type: str,
         file_handler: Union[str, DictConfig, Dict],
         batch_size: int,
-        features_path: Optional[str] = None,
         inference_batch_size: Optional[int] = None,
+        features_path: Optional[str] = None,
         train_transform: Optional[SmartCompose] = None,
         dev_transform: Optional[SmartCompose] = None,
         test_transform: Optional[SmartCompose] = None,
@@ -60,12 +60,12 @@ class DCASE2018Task3(BaseClassificationDataset):
             file_type: File type of the features.
             file_handler: File handler to load the data.
             batch_size: Batch size.
+            inference_batch_size: Inference batch size. If None, defaults to
+                batch_size. Defaults to None.
             features_path: Root path to features. Useful
                 when features need to be extracted and stored
                 in a different folder than the root of the dataset.
                 If `None`, will be set to `path`. Defaults to `None`.
-            inference_batch_size: Inference batch size. If None, defaults to
-                batch_size. Defaults to None.
             train_transform: Transform to apply to the training set.
                 Defaults to None.
             dev_transform: Transform to apply to the development set.
@@ -92,8 +92,8 @@ class DCASE2018Task3(BaseClassificationDataset):
             file_type=file_type,
             file_handler=file_handler,
             batch_size=batch_size,
-            features_path=features_path,
             inference_batch_size=inference_batch_size,
+            features_path=features_path,
             train_transform=train_transform,
             dev_transform=dev_transform,
             test_transform=test_transform,

--- a/autrainer/datasets/dcase_2020_t1a.py
+++ b/autrainer/datasets/dcase_2020_t1a.py
@@ -57,8 +57,8 @@ class DCASE2020Task1A(BaseClassificationDataset):
         file_type: str,
         file_handler: Union[str, DictConfig, Dict],
         batch_size: int,
-        features_path: Optional[str] = None,
         inference_batch_size: Optional[int] = None,
+        features_path: Optional[str] = None,
         train_transform: Optional[SmartCompose] = None,
         dev_transform: Optional[SmartCompose] = None,
         test_transform: Optional[SmartCompose] = None,
@@ -85,12 +85,12 @@ class DCASE2020Task1A(BaseClassificationDataset):
             file_type: File type of the features.
             file_handler: File handler to load the data.
             batch_size: Batch size.
+            inference_batch_size: Inference batch size. If None, defaults to
+                batch_size. Defaults to None.
             features_path: Root path to features. Useful
                 when features need to be extracted and stored
                 in a different folder than the root of the dataset.
                 If `None`, will be set to `path`. Defaults to `None`.
-            inference_batch_size: Inference batch size. If None, defaults to
-                batch_size. Defaults to None.
             train_transform: Transform to apply to the training set.
                 Defaults to None.
             dev_transform: Transform to apply to the development set.
@@ -124,8 +124,8 @@ class DCASE2020Task1A(BaseClassificationDataset):
             file_type=file_type,
             file_handler=file_handler,
             batch_size=batch_size,
-            features_path=features_path,
             inference_batch_size=inference_batch_size,
+            features_path=features_path,
             train_transform=train_transform,
             dev_transform=dev_transform,
             test_transform=test_transform,

--- a/autrainer/datasets/edansa2019.py
+++ b/autrainer/datasets/edansa2019.py
@@ -29,8 +29,8 @@ class EDANSA2019(BaseMLClassificationDataset):
         file_type: str,
         file_handler: Union[str, DictConfig, Dict],
         batch_size: int,
-        features_path: Optional[str] = None,
         inference_batch_size: Optional[int] = None,
+        features_path: Optional[str] = None,
         train_transform: Optional[SmartCompose] = None,
         dev_transform: Optional[SmartCompose] = None,
         test_transform: Optional[SmartCompose] = None,
@@ -53,12 +53,12 @@ class EDANSA2019(BaseMLClassificationDataset):
             file_type: File type of the features.
             file_handler: File handler to load the data.
             batch_size: Batch size.
+            inference_batch_size: Inference batch size. If None, defaults to
+                batch_size. Defaults to None.
             features_path: Root path to features. Useful
                 when features need to be extracted and stored
                 in a different folder than the root of the dataset.
                 If `None`, will be set to `path`. Defaults to `None`.
-            inference_batch_size: Inference batch size. If None, defaults to
-                batch_size. Defaults to None.
             train_transform: Transform to apply to the training set.
                 Defaults to None.
             dev_transform: Transform to apply to the development set.
@@ -79,8 +79,8 @@ class EDANSA2019(BaseMLClassificationDataset):
             file_type=file_type,
             file_handler=file_handler,
             batch_size=batch_size,
-            features_path=features_path,
             inference_batch_size=inference_batch_size,
+            features_path=features_path,
             train_transform=train_transform,
             dev_transform=dev_transform,
             test_transform=test_transform,

--- a/autrainer/datasets/emo_db.py
+++ b/autrainer/datasets/emo_db.py
@@ -38,8 +38,8 @@ class EmoDB(BaseClassificationDataset):
         file_type: str,
         file_handler: Union[str, DictConfig, Dict],
         batch_size: int,
-        features_path: Optional[str] = None,
         inference_batch_size: Optional[int] = None,
+        features_path: Optional[str] = None,
         train_transform: Optional[SmartCompose] = None,
         dev_transform: Optional[SmartCompose] = None,
         test_transform: Optional[SmartCompose] = None,
@@ -64,12 +64,12 @@ class EmoDB(BaseClassificationDataset):
             file_type: File type of the features.
             file_handler: File handler to load the data.
             batch_size: Batch size.
+            inference_batch_size: Inference batch size. If None, defaults to
+                batch_size. Defaults to None.
             features_path: Root path to features. Useful
                 when features need to be extracted and stored
                 in a different folder than the root of the dataset.
                 If `None`, will be set to `path`. Defaults to `None`.
-            inference_batch_size: Inference batch size. If None, defaults to
-                batch_size. Defaults to None.
             train_transform: Transform to apply to the training set.
                 Defaults to None.
             dev_transform: Transform to apply to the development set.

--- a/autrainer/datasets/speech_commands.py
+++ b/autrainer/datasets/speech_commands.py
@@ -25,8 +25,8 @@ class SpeechCommands(BaseClassificationDataset):
         file_type: str,
         file_handler: Union[str, DictConfig, Dict],
         batch_size: int,
-        features_path: Optional[str] = None,
         inference_batch_size: Optional[int] = None,
+        features_path: Optional[str] = None,
         train_transform: Optional[SmartCompose] = None,
         dev_transform: Optional[SmartCompose] = None,
         test_transform: Optional[SmartCompose] = None,
@@ -48,12 +48,12 @@ class SpeechCommands(BaseClassificationDataset):
             file_type: File type of the features.
             file_handler: File handler to load the data.
             batch_size: Batch size.
+            inference_batch_size: Inference batch size. If None, defaults to
+                batch_size. Defaults to None.
             features_path: Root path to features. Useful
                 when features need to be extracted and stored
                 in a different folder than the root of the dataset.
                 If `None`, will be set to `path`. Defaults to `None`.
-            inference_batch_size: Inference batch size. If None, defaults to
-                batch_size. Defaults to None.
             train_transform: Transform to apply to the training set.
                 Defaults to None.
             dev_transform: Transform to apply to the development set.
@@ -73,8 +73,8 @@ class SpeechCommands(BaseClassificationDataset):
             file_type=file_type,
             file_handler=file_handler,
             batch_size=batch_size,
-            features_path=features_path,
             inference_batch_size=inference_batch_size,
+            features_path=features_path,
             train_transform=train_transform,
             dev_transform=dev_transform,
             test_transform=test_transform,


### PR DESCRIPTION
Small fix reordering the dataset arguments such that `inference_batch_size` comes directly after `batch_size` and `features_path` afterwards.