### PR TITLE
Support Remote Code for Hugging Face Inference

### DIFF
--- a/autrainer/core/scripts/inference_script.py
+++ b/autrainer/core/scripts/inference_script.py
@@ -26,6 +26,7 @@ class InferenceArgs:
     stride_length: Optional[float]
     min_length: Optional[float]
     sample_rate: Optional[int]
+    trust_remote: bool = False
 
 
 class InferenceScript(AbstractScript):
@@ -204,6 +205,16 @@ class InferenceScript(AbstractScript):
                 "sliding window inference. Defaults to None."
             ),
         )
+        self.parser.add_argument(
+            "-t",
+            "--trust-remote",
+            action="store_true",
+            help=(
+                "Whether to trust and execute custom Python code from Hugging "
+                "Face models. Warning: This can be dangerous as it may run "
+                "arbitrary code on your machine! Defaults to False."
+            ),
+        )
 
     def main(self, args: InferenceArgs) -> None:
         args.model = self._assert_model_exists(args)
@@ -217,7 +228,7 @@ class InferenceScript(AbstractScript):
         from autrainer.serving import get_model_path
 
         try:
-            return get_model_path(args.model)
+            return get_model_path(args.model, args.trust_remote)
         except ValueError as e:
             raise CommandLineError(self.parser, str(e), code=1)
 
@@ -374,6 +385,7 @@ def inference(
     stride_length: Optional[float] = None,
     min_length: Optional[float] = None,
     sample_rate: Optional[int] = None,
+    trust_remote: bool = False,
 ) -> None:
     """Perform inference on a trained model.
 
@@ -419,6 +431,9 @@ def inference(
             length is enforced. Defaults to None.
         sample_rate: Sample rate of audio files in Hz. Has to be specified for
             sliding window inference. Defaults to None.
+        trust_remote: Whether to trust and execute custom Python code from
+            Hugging Face models. Warning: This can be dangerous as it may run
+            arbitrary code on your machine! Defaults to False.
 
     Raises:
         CommandLineError: If the model, input, or preprocessing configuration
@@ -442,5 +457,6 @@ def inference(
             stride_length,
             min_length,
             sample_rate,
+            trust_remote,
         )
     )

--- a/autrainer/serving/model_paths.py
+++ b/autrainer/serving/model_paths.py
@@ -2,6 +2,7 @@ from abc import ABC, abstractmethod
 import os
 from pathlib import Path
 import re
+import sys
 from typing import List, Optional, Tuple
 
 
@@ -72,8 +73,9 @@ class LocalModelPath(AbstractModelPath):
 
 
 class HubModelPath(AbstractModelPath):
-    def __init__(self, model_path: str) -> None:
+    def __init__(self, model_path: str, trust_remote: bool) -> None:
         super().__init__(model_path)
+        self.trust_remote = trust_remote
         self.verify()
 
     def verify(self) -> None:
@@ -120,6 +122,21 @@ class HubModelPath(AbstractModelPath):
             for f in files
             if f.startswith(model_file_loc) and f.endswith(SAVE_FILES)
         ]
+        python_files = [
+            Path(f).as_posix()
+            for f in files
+            if f.startswith(model_file_loc) and f.endswith(".py")
+        ]
+        if python_files and not self.trust_remote:
+            raise ValueError(
+                f"The Hugging Face repository '{repo_id}' likely requires "
+                "the execution of custom Python code.\nTo trust the remote "
+                "repository, pass the '--trust-remote' flag.\n\nWarning: "
+                "This can be dangerous as it may run arbitrary code on your "
+                "machine!"
+            )
+
+        self.files.extend(python_files)
         self.subdir = model_file_loc
 
     def create_model_path(self) -> str:
@@ -134,7 +151,10 @@ class HubModelPath(AbstractModelPath):
             Local directory of the model.
         """
         self._download()
-        return os.path.join(self.local_dir, self.subdir)
+        local_path = os.path.join(self.local_dir, self.subdir)
+        if self.trust_remote:
+            sys.path.append(local_path)
+        return local_path
 
     def _parse_hub_path(
         self,
@@ -222,7 +242,7 @@ class HubModelPath(AbstractModelPath):
                 )
 
 
-def get_model_path(model_path: str) -> str:
+def get_model_path(model_path: str, trust_remote: bool) -> str:
     if model_path.startswith("hf:"):
-        return HubModelPath(model_path).get_model_path()
+        return HubModelPath(model_path, trust_remote).get_model_path()
     return LocalModelPath(model_path).get_model_path()

--- a/autrainer/serving/model_paths.py
+++ b/autrainer/serving/model_paths.py
@@ -231,7 +231,7 @@ class HubModelPath(AbstractModelPath):
         hf_api = HfApi(endpoint=os.environ.get("HF_ENDPOINT"))
         pbar = tqdm(self.files, desc="Downloading:")
         for file in pbar:
-            pbar.set_description(f"Downloading: {file}")
+            pbar.set_description(f"Downloading: {os.path.basename(file)}")
             with silence():
                 hf_api.hf_hub_download(
                     repo_id=self.repo_id,


### PR DESCRIPTION
Closes #19 by automatically downloading and allowing to the execution of remote code hosted in a hugging face repository such that users can share custom model implementations that can be used for inference.

Since this is absolutely not safe the option is deactivated by default and we take some security precautions.
If the path to a repo containing custom Python code is specified and `--trust-remote` is not passed, we fail printing the message below and do not download anything. `--trust-remote` also needs to be passed when the model is already downloaded.
```
The Hugging Face repository 'some/remote-repo' likely requires the execution of custom Python code.
To trust the remote repository, pass the '--trust-remote' flag.

Warning: This can be dangerous as it may run arbitrary code on your machine!
```