### PR TITLE
Fix Dataset Dataframe Inconsistencies

### DIFF
--- a/autrainer/datasets/abstract_dataset.py
+++ b/autrainer/datasets/abstract_dataset.py
@@ -184,14 +184,29 @@ class AbstractDataset(ABC):
 
     @cached_property
     def df_train(self) -> pd.DataFrame:
+        """Dataframe for the training set, loaded from `train.csv` by default.
+
+        Returns:
+            Training dataframe.
+        """
         return pd.read_csv(os.path.join(self.path, "train.csv"))
 
     @cached_property
     def df_dev(self) -> pd.DataFrame:
+        """Dataframe for the development set, loaded from `dev.csv` by default.
+
+        Returns:
+            Development dataframe.
+        """
         return pd.read_csv(os.path.join(self.path, "dev.csv"))
 
     @cached_property
     def df_test(self) -> pd.DataFrame:
+        """Dataframe for the test set, loaded from `test.csv` by default.
+
+        Returns:
+            Test dataframe.
+        """
         return pd.read_csv(os.path.join(self.path, "test.csv"))
 
     def _init_dataset(

--- a/autrainer/datasets/abstract_dataset.py
+++ b/autrainer/datasets/abstract_dataset.py
@@ -105,11 +105,10 @@ class AbstractDataset(ABC):
         self.stratify = stratify or []
 
         self._generator = torch.Generator().manual_seed(self.seed)
-        self.df_train, self.df_dev, self.df_test = self.load_dataframes()
         self._assert_stratify()
 
     @property
-    def audio_subdir(self):
+    def audio_subdir(self) -> str:
         """Subfolder containing audio data.
 
         Defaults to `default` for our standard format.
@@ -183,30 +182,16 @@ class AbstractDataset(ABC):
             instance_of=AbstractFileHandler,
         )
 
-    def load_dataframes(
-        self,
-    ) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
-        """Load the dataframes.
-
-        Returns:
-            Dataframes for training, development, and testing.
-        """
-        return (
-            self.train_df,
-            self.dev_df,
-            self.test_df,
-        )
-
     @cached_property
-    def train_df(self):
+    def df_train(self) -> pd.DataFrame:
         return pd.read_csv(os.path.join(self.path, "train.csv"))
 
     @cached_property
-    def dev_df(self):
+    def df_dev(self) -> pd.DataFrame:
         return pd.read_csv(os.path.join(self.path, "dev.csv"))
 
     @cached_property
-    def test_df(self):
+    def df_test(self) -> pd.DataFrame:
         return pd.read_csv(os.path.join(self.path, "test.csv"))
 
     def _init_dataset(

--- a/autrainer/datasets/aibo.py
+++ b/autrainer/datasets/aibo.py
@@ -120,7 +120,7 @@ class AIBO(BaseClassificationDataset):
             )
 
     @property
-    def audio_subdir(self):
+    def audio_subdir(self) -> str:
         """Subfolder containing audio data."""
         return "wav"
 
@@ -140,7 +140,7 @@ class AIBO(BaseClassificationDataset):
         return df
 
     @cached_property
-    def train_df(self) -> pd.DataFrame:
+    def df_train(self) -> pd.DataFrame:
         df = self._load_df
         df_train_dev = df.loc[df["school"] == "Ohm"]
         speakers = sorted(df_train_dev["speaker"].unique())
@@ -150,7 +150,7 @@ class AIBO(BaseClassificationDataset):
         return df_train
 
     @cached_property
-    def dev_df(self) -> pd.DataFrame:
+    def df_dev(self) -> pd.DataFrame:
         df = self._load_df
         df_train_dev = df.loc[df["school"] == "Ohm"]
         speakers = sorted(df_train_dev["speaker"].unique())
@@ -158,7 +158,7 @@ class AIBO(BaseClassificationDataset):
         return df_dev
 
     @cached_property
-    def test_df(self) -> pd.DataFrame:
+    def df_test(self) -> pd.DataFrame:
         df = self._load_df
         df_test = df.loc[df["school"] == "Mont"]
         return df_test

--- a/autrainer/datasets/dcase_2016_t1.py
+++ b/autrainer/datasets/dcase_2016_t1.py
@@ -107,19 +107,19 @@ class DCASE2016Task1(BaseClassificationDataset):
         )
 
     @cached_property
-    def train_df(self):
+    def df_train(self) -> pd.DataFrame:
         return pd.read_csv(
             os.path.join(self.path, f"fold{self.fold}_train.csv")
         )
 
     @cached_property
-    def dev_df(self):
+    def df_dev(self) -> pd.DataFrame:
         return pd.read_csv(
             os.path.join(self.path, f"fold{self.fold}_evaluate.csv")
         )
 
     @cached_property
-    def test_df(self):
+    def df_test(self) -> pd.DataFrame:
         return pd.read_csv(os.path.join(self.path, "test.csv"))
 
     @staticmethod

--- a/autrainer/datasets/dcase_2018_t3.py
+++ b/autrainer/datasets/dcase_2018_t3.py
@@ -1,3 +1,4 @@
+from functools import cached_property
 import os
 import shutil
 from typing import Dict, List, Optional, Tuple, Union
@@ -100,17 +101,17 @@ class DCASE2018Task3(BaseClassificationDataset):
             stratify=stratify,
         )
 
-    def load_dataframes(
+    @cached_property
+    def _load_train_dev_df(
         self,
-    ) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
+    ) -> Tuple[pd.DataFrame, pd.DataFrame]:
         df_train = pd.read_csv(os.path.join(self.path, "train.csv"))
         df_dev = pd.read_csv(os.path.join(self.path, "test.csv"))
-        df_test = pd.read_csv(os.path.join(self.path, "test.csv"))
 
         if self.dev_split > 0:
             df_train, df_dev = self._split_train_dataset(df_train)
 
-        return df_train, df_dev, df_test
+        return df_train, df_dev
 
     def _split_train_dataset(
         self,
@@ -123,6 +124,14 @@ class DCASE2018Task3(BaseClassificationDataset):
             df[df.index.isin(train_indices)].copy(),
             df[~df.index.isin(train_indices)].copy(),
         )
+
+    @cached_property
+    def df_train(self) -> pd.DataFrame:
+        return self._load_train_dev_df[0]
+
+    @cached_property
+    def df_dev(self) -> pd.DataFrame:
+        return self._load_train_dev_df[1]
 
     @staticmethod
     def download(path: str) -> None:  # pragma: no cover

--- a/autrainer/datasets/emo_db.py
+++ b/autrainer/datasets/emo_db.py
@@ -107,19 +107,19 @@ class EmoDB(BaseClassificationDataset):
         )
 
     @cached_property
-    def meta(self):
+    def meta(self) -> pd.DataFrame:
         return pd.read_csv(os.path.join(self.path, "metadata.csv"))
 
     @cached_property
-    def train_df(self):
+    def df_train(self) -> pd.DataFrame:
         return self.meta[self.meta["speaker"].isin(self.train_speakers)]
 
     @cached_property
-    def dev_df(self):
+    def df_dev(self) -> pd.DataFrame:
         return self.meta[self.meta["speaker"].isin(self.dev_speakers)]
 
     @cached_property
-    def test_df(self):
+    def df_test(self) -> pd.DataFrame:
         return self.meta[self.meta["speaker"].isin(self.test_speakers)]
 
     @staticmethod

--- a/autrainer/training/training.py
+++ b/autrainer/training/training.py
@@ -114,10 +114,6 @@ class ModularTaskTrainer:
         self.train_dataset = self.data.train_dataset
         self.dev_dataset = self.data.dev_dataset
         self.test_dataset = self.data.test_dataset
-        self.df_dev, self.df_test, self.stratify, self.target_transform = (
-            self.data.get_evaluation_data()
-        )
-        self.task = self.data.task
 
         # ? Misc Training Parameters
         self.disable_progress_bar = not self.cfg.get("progress_bar", False)
@@ -232,7 +228,7 @@ class ModularTaskTrainer:
             )
 
         self.bookkeeping.save_audobject(
-            self.target_transform, "target_transform.yaml"
+            self.data.target_transform, "target_transform.yaml"
         )
         self.bookkeeping.save_audobject(self.model, "model.yaml")
         self.bookkeeping.save_audobject(
@@ -395,7 +391,7 @@ class ModularTaskTrainer:
             -1,
             "_test",
             self.test_loader,
-            self.df_test,
+            self.data.df_test,
             dev_evaluation=False,
             save_to="test_holistic",
             tracker=self.test_tracker,
@@ -506,7 +502,7 @@ class ModularTaskTrainer:
                     epoch,
                     epoch_folder,
                     self.dev_loader,
-                    self.df_dev,
+                    self.data.df_dev,
                     tracker=self.dev_tracker,
                 )
                 self.dev_timer.stop()
@@ -601,7 +597,7 @@ class ModularTaskTrainer:
                     step,
                     step_folder,
                     self.dev_loader,
-                    self.df_dev,
+                    self.data.df_dev,
                     tracker=self.dev_tracker,
                 )
                 self.dev_timer.stop()
@@ -725,7 +721,7 @@ class ModularTaskTrainer:
             groundtruth=df,
             metrics=self.data.metrics,
             target_column=self.data.target_column,
-            stratify=self.stratify,
+            stratify=self.data.stratify,
         )
         if dev_evaluation:
             logging_results["dev_loss"] = {"all": results["dev_loss"]}

--- a/docs/source/examples/tutorials/esc_50.py
+++ b/docs/source/examples/tutorials/esc_50.py
@@ -1,6 +1,7 @@
+from functools import cached_property
 import os
 import shutil
-from typing import Any, Dict, List, Tuple
+from typing import Any, Dict, List
 
 import pandas as pd
 
@@ -24,15 +25,24 @@ class ESC50(BaseClassificationDataset):
         self.test_folds = test_folds
         super().__init__(**kwargs)
 
-    def load_dataframes(
-        self,
-    ) -> Tuple[pd.DataFrame, pd.DataFrame, pd.DataFrame]:
-        meta = pd.read_csv(os.path.join(self.path, "esc50.csv"))
-        return (
-            meta[meta["fold"].isin(self.train_folds)],
-            meta[meta["fold"].isin(self.dev_folds)],
-            meta[meta["fold"].isin(self.test_folds)],
-        )
+    @cached_property
+    def _load_metadata(self) -> pd.DataFrame:
+        return pd.read_csv(os.path.join(self.path, "esc50.csv"))
+
+    @cached_property
+    def df_train(self) -> pd.DataFrame:
+        meta = self._load_metadata
+        return meta[meta["fold"].isin(self.train_folds)]
+
+    @cached_property
+    def df_dev(self) -> pd.DataFrame:
+        meta = self._load_metadata
+        return meta[meta["fold"].isin(self.dev_folds)]
+
+    @cached_property
+    def df_test(self) -> pd.DataFrame:
+        meta = self._load_metadata
+        return meta[meta["fold"].isin(self.test_folds)]
 
     @staticmethod
     def download(path: str) -> None:

--- a/docs/source/modules/datasets.rst
+++ b/docs/source/modules/datasets.rst
@@ -39,7 +39,9 @@ For instance, a file in the :attr:`index_column` might be :file:`optional/subdir
 where :file:`some.file` is an audio or a feature file.
 
 In order to load custom dataset splits that do not follow the standard :file:`train.csv`, :file:`dev.csv`, and :file:`test.csv` convention,
-the :meth:`~autrainer.datasets.AbstractDataset.load_dataframes` method can be overwritten (see :ref:`custom datasets tutorial <tut_datasets>`).
+the :attr:`~autrainer.datasets.AbstractDataset.df_train`, :attr:`~autrainer.datasets.AbstractDataset.df_dev`,
+and :attr:`~autrainer.datasets.AbstractDataset.df_test`, properties of the dataset class can be overwritten
+(see :ref:`custom datasets tutorial <tut_datasets>`).
 
 **Training and Evaluation**
 

--- a/docs/source/usage/tutorials.rst
+++ b/docs/source/usage/tutorials.rst
@@ -71,9 +71,10 @@ and :attr:`~autrainer.datasets.AbstractDataset.output_dim` properties.
 
 The train, dev, and test datasets as well as loaders are automatically created by the abstract class.
 However, this requires that the dataset structure follows the standard format outlined in the :ref:`dataset documentation <datasets>`.
-If the dataset structure is different or does not rely on dataframes, the :meth:`~autrainer.datasets.AbstractDataset.load_dataframes`,
-:attr:`~autrainer.datasets.AbstractDataset.train_dataset`, :attr:`~autrainer.datasets.AbstractDataset.train_loader` etc.
-methods and properties can be overridden.
+If the dataset structure is different or does not rely on dataframes, the 
+:attr:`~autrainer.datasets.AbstractDataset.df_train`, :attr:`~autrainer.datasets.AbstractDataset.df_dev`,
+and :attr:`~autrainer.datasets.AbstractDataset.df_test`, :attr:`~autrainer.datasets.AbstractDataset.train_dataset`,
+:attr:`~autrainer.datasets.AbstractDataset.train_loader` etc. properties can be overridden.
 
 `autrainer` provides base datasets for classification (:class:`~autrainer.datasets.BaseClassificationDataset`),
 regression (:class:`~autrainer.datasets.BaseRegressionDataset`),
@@ -99,8 +100,9 @@ For example, the `ESC-50 <https://github.com/karolpiczak/ESC-50>`_ dataset is an
 The dataset provides audio files by default (which are moved to the :file:`default/` directory in the
 :meth:`~autrainer.datasets.AbstractDataset.download` method) and the corresponding metadata of the dataset is stored in the :file:`esc50.csv` file.
 
-To allow the the specification of custom folds, the :meth:`~autrainer.datasets.AbstractDataset.load_dataframes`
-method is overridden to split the :file:`esc50.csv` file into the respective train, dev, and test dataframes.
+To allow the the specification of custom folds, the :attr:`~autrainer.datasets.AbstractDataset.df_train`,
+:attr:`~autrainer.datasets.AbstractDataset.df_dev`, and :attr:`~autrainer.datasets.AbstractDataset.df_test` properties are overridden
+to split the :file:`esc50.csv` metadata file into the respective train, dev, and test dataframes.
 This also allows for cross-validation by creating multiple configurations with different folds.
 
 To extract log-Mel spectrograms from the audio files, a :ref:`preprocessing transform <preprocessing_transforms>`

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -226,11 +226,11 @@ class TestBaseDatasets(BaseIndividualTempDir):
         y_shape: Tuple[int, ...],
     ) -> None:
         assert data.output_dim == output_dim, f"Should be {output_dim}."
-        df_dev, df_test, _, target_trans = data.get_evaluation_data()
-        assert isinstance(df_dev, pd.DataFrame), "Should be a DataFrame."
-        assert isinstance(df_test, pd.DataFrame), "Should be a DataFrame."
+        assert isinstance(data.df_dev, pd.DataFrame), "Should be a DataFrame."
+        assert isinstance(data.df_test, pd.DataFrame), "Should be a DataFrame."
         assert isinstance(
-            target_trans, AbstractTargetTransform
+            data.target_transform,
+            AbstractTargetTransform,
         ), "Should be an instance of AbstractTargetTransform."
 
         assert isinstance(

--- a/tests/test_datasets.py
+++ b/tests/test_datasets.py
@@ -277,7 +277,7 @@ class TestAIBO(BaseIndividualTempDir):
         df = pd.DataFrame()
         random.seed(42)
 
-        def school():
+        def school() -> str:
             if random.random() < 0.5:
                 return "Ohm"
             else:
@@ -555,7 +555,7 @@ class TestToyDataset(BaseIndividualTempDir):
         kwargs = self._mock_toy_dataset_kwargs()
         kwargs["size"] = size
         with pytest.raises(ValueError):
-            ToyDataset(**kwargs)
+            ToyDataset(**kwargs).df_train
 
     @staticmethod
     def _test_data_shapes(


### PR DESCRIPTION
After https://github.com/autrainer/autrainer/pull/54, we ended up with a usable, but pretty weird train, dev, and test dataframe management:
- we added the `train_df`, `dev_df`, and `test_df` properties for the user to overwrite conveniently
- these would then be collected in the `load_dataframes` method of the dataset which we document and tell the user to override for custom datasets, which would now be unnecessary when they overwrite the properties above anyways
- however internally, `load_dataframes` maps to the `df_train`, `df_dev`, and `df_test` attributes which are used throughout autrainer everywhere :D

So this unifies our weird setup, completely removes the `load_dataframes` method, just using the `df_train`, `df_dev`, and `df_test` properties for everything.

Additionally, this removes the kinda unnecessary `get_evaluation_data` method from the dataset, that served little to no purpose as all properties can directly be accessed on the dataset.

