### PR TITLE
Fix Per-Example Loss and Refactor Outputs Tracker

### DIFF
--- a/autrainer/core/wrappers/instantiate.py
+++ b/autrainer/core/wrappers/instantiate.py
@@ -36,7 +36,7 @@ def instantiate(
     convert: Optional[HydraConvertEnum] = None,
     recursive: bool = False,
     **kwargs,
-) -> Optional[T]:
+) -> T:
     """Instantiate an object from a configuration Dict or DictConfig.
 
     The config must contain a `_target_` field that specifies a relative import
@@ -94,7 +94,7 @@ def instantiate_shorthand(
     convert: Optional[HydraConvertEnum] = None,
     recursive: bool = False,
     **kwargs,
-) -> Optional[T]:
+) -> T:
     """Instantiate an object from a shorthand configuration.
 
     A shorthand config is either a string or a dictionary with a single key.

--- a/autrainer/criterions/criterion_wrappers.py
+++ b/autrainer/criterions/criterion_wrappers.py
@@ -41,8 +41,7 @@ class BalancedCrossEntropyLoss(CrossEntropyLoss):
             .values
         )
         weight = torch.tensor(1 / frequency, dtype=torch.float32)
-        weight /= weight.sum()
-        self.weight = weight
+        self.weight = weight * len(weight) / weight.sum()
 
 
 class MSELoss(torch.nn.MSELoss):

--- a/docs/source/examples/optimizer_custom_step.py
+++ b/docs/source/examples/optimizer_custom_step.py
@@ -11,7 +11,7 @@ class SomeOptimizer(torch.optim.Optimizer):
         target: torch.Tensor,
         criterion: torch.nn.Module,
         probabilities_fn: Callable,
-    ) -> Tuple[float, torch.Tensor]:
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         """Custom step function for the optimizer.
 
         Args:
@@ -22,5 +22,5 @@ class SomeOptimizer(torch.optim.Optimizer):
             probabilities_fn: Function to get probabilities from model outputs.
 
         Returns:
-            Reduced loss over the batch and detached model outputs.
+            Tuple containing the non-reduced loss and model outputs.
         """

--- a/docs/source/examples/tutorials/random_scaled_sgd.py
+++ b/docs/source/examples/tutorials/random_scaled_sgd.py
@@ -35,13 +35,13 @@ class RandomScaledSGD(torch.optim.Optimizer):
         target: torch.Tensor,  # batched target data
         criterion: torch.nn.Module,  # loss function
         probabilities_fn: Callable,  # function to get probabilities from model outputs
-    ) -> Tuple[float, torch.Tensor]:
+    ) -> Tuple[torch.Tensor, torch.Tensor]:
         self.zero_grad()
         output = model(data)
         loss = criterion(probabilities_fn(output), target)
-        loss.backward()
+        loss.mean().backward()
         if torch.rand(1, generator=self.g).item() < self.p:
             self.param_groups[0]["lr"] *= self.scaling_factor
         self.step()
         self.param_groups[0]["lr"] = self.base_lr
-        return loss.item(), output.detach()
+        return loss, output

--- a/docs/source/modules/criterions.rst
+++ b/docs/source/modules/criterions.rst
@@ -10,6 +10,14 @@ Criterions are specified in the :ref:`Dataset<datasets>` configuration with :ref
    To create custom criterions, refer to the :ref:`custom criterions tutorial <tut_criterions>`.
 
 
+.. note::
+
+   The :attr:`reduction` attribute of each criterion is automatically set to :attr:`"none"` during training, validation, and testing.
+   This allows the per-example loss to be reported directly, without the need for re-calculating the loss for logging purposes.
+
+   This is handled automatically during the instantiation of the criterion.
+
+
 Criterion Wrappers
 ------------------
 

--- a/docs/source/modules/optimizers.rst
+++ b/docs/source/modules/optimizers.rst
@@ -31,9 +31,8 @@ For example, :class:`torch.optim.Adam` can be used as follows:
 
    .. configurations::
       :subdir: optimizer
-      :configs: Adam SGD
-      :headline:
-
+      :configs: SGD Adam AdamW Adadelta Adagrad Adamax NAdam RAdam SparseAdam RMSprop Rprop ASGD LBFGS
+      :exact:
 
 .. _custom_optimizers:
 

--- a/docs/source/usage/tutorials.rst
+++ b/docs/source/usage/tutorials.rst
@@ -194,6 +194,11 @@ To create a custom :ref:`criterion <criterions>`, inherit from :class:`torch.nn.
 If the criterion relies on the dataset, an optional :ref:`criterion setup method <criterion_setup>`
 can be defined which is called after the dataset is initialized.
 
+.. note::
+
+   The :attr:`reduction` attribute of each criterion is automatically set to :attr:`"none"` during instantiation and
+   the :meth:`forward` method should return the per-example loss.
+
 For example, the following criterion implements `CrossEntropyLoss <https://pytorch.org/docs/stable/generated/torch.nn.CrossEntropyLoss.html>`_
 with an additional scaling factor:
 

--- a/tests/test_criterions.py
+++ b/tests/test_criterions.py
@@ -27,7 +27,7 @@ class TestBalancedCrossEntropyLoss:
             criterion.weight is not None
         ), "Should have calculated the weights"
         test_weights = torch.tensor([1 / 1, 1 / 2, 1 / 3], dtype=torch.float32)
-        test_weights /= test_weights.sum()
+        test_weights = test_weights * len(test_weights) / test_weights.sum()
         assert torch.allclose(
             criterion.weight, test_weights
         ), "Should have calculated frequency-based weights"


### PR DESCRIPTION
Closes #84 by ensuring that the `BalancedCrossEntropyLoss` weights sum up to the number of classes.

Draft:
Both the mean-reduced loss and non-reduced loss with a manual mean call are now the same (aside from some small numerical differences introduced through the manual `loss.mean()` call).
This allows us to compute the non-reduced loss during all forward passes directly, and pass these values to the tracker instead of recomputing the per-example losses again.

Let me know if you think it is a good idea to combine the forward calculation and tracking with the non-reduced loss during training.


TODO:
- [x] update docs to indicate that we use a non-reduced loss during training