### PR TITLE
Speed up Trainer Initialization

### DIFF
--- a/autrainer/core/scripts/preprocess_script.py
+++ b/autrainer/core/scripts/preprocess_script.py
@@ -2,7 +2,6 @@ from dataclasses import dataclass
 from typing import Optional
 
 from omegaconf import DictConfig, OmegaConf
-import torch
 
 import autrainer
 from autrainer.core.scripts.abstract_script import MockParser
@@ -35,6 +34,7 @@ def preprocess_main(
     import os
     from pathlib import Path
 
+    import torch
     from tqdm import tqdm
 
     from autrainer.datasets.utils import AbstractFileHandler

--- a/autrainer/core/utils/__init__.py
+++ b/autrainer/core/utils/__init__.py
@@ -1,5 +1,11 @@
 from .bookkeeping import Bookkeeping
-from .hardware import get_hardware_info, save_hardware_info, set_device
+from .hardware import (
+    get_hardware_info,
+    save_hardware_info,
+    set_device,
+    spawn_thread,
+)
+from .requirements import save_requirements
 from .set_seed import set_seed
 from .silence import silence
 from .timer import Timer
@@ -9,8 +15,10 @@ __all__ = [
     "Bookkeeping",
     "get_hardware_info",
     "save_hardware_info",
+    "save_requirements",
     "set_device",
     "set_seed",
     "silence",
+    "spawn_thread",
     "Timer",
 ]

--- a/autrainer/core/utils/hardware.py
+++ b/autrainer/core/utils/hardware.py
@@ -9,16 +9,14 @@ import psutil
 import torch
 
 
-def spawn_thread(target: Callable, args: tuple = (), daemon=False) -> None:
+def spawn_thread(target: Callable, args: tuple = ()) -> None:
     """Spawn and start a new thread for the target function.
 
     Args:
         target: Function to run in the thread.
         args: Arguments to pass to the function. Defaults to an empty tuple.
-        daemon: Whether the thread should be run as a daemon thread.
-            Defaults to False.
     """
-    threading.Thread(target=target, args=args, daemon=daemon).start()
+    threading.Thread(target=target, args=args).start()
 
 
 def get_gpu_info(device: torch.device) -> Optional[dict]:

--- a/autrainer/core/utils/hardware.py
+++ b/autrainer/core/utils/hardware.py
@@ -1,11 +1,24 @@
 import logging
 import os
 import platform
-from typing import Optional
+import threading
+from typing import Callable, Optional
 
 from omegaconf import OmegaConf
 import psutil
 import torch
+
+
+def spawn_thread(target: Callable, args: tuple = (), daemon=False) -> None:
+    """Spawn and start a new thread for the target function.
+
+    Args:
+        target: Function to run in the thread.
+        args: Arguments to pass to the function. Defaults to an empty tuple.
+        daemon: Whether the thread should be run as a daemon thread.
+            Defaults to False.
+    """
+    threading.Thread(target=target, args=args, daemon=daemon).start()
 
 
 def get_gpu_info(device: torch.device) -> Optional[dict]:

--- a/autrainer/core/utils/requirements.py
+++ b/autrainer/core/utils/requirements.py
@@ -1,0 +1,7 @@
+import os
+
+
+def save_requirements(output_directory: str) -> None:
+    reqs_output = os.path.join(output_directory, "requirements.txt")
+    with open(reqs_output, "w") as f:
+        f.write(os.popen("pip freeze").read())

--- a/autrainer/training/training.py
+++ b/autrainer/training/training.py
@@ -230,7 +230,7 @@ class ModularTaskTrainer:
             (self.scheduler, "scheduler.pt", "_best"),
         ]
         for task in save_tasks:
-            spawn_thread(self.bookkeeping.save_audobject, task)
+            spawn_thread(self.bookkeeping.save_state, task)
 
         # ? Load and Save Preprocessing Pipeline if specified
         _preprocess_pipe = SmartCompose([])

--- a/autrainer/training/training.py
+++ b/autrainer/training/training.py
@@ -221,17 +221,16 @@ class ModularTaskTrainer:
         self.best_iteration = 1
 
         # ? Save initial (and best) Model, Optimizer and Scheduler states
-        [
-            spawn_thread(self.bookkeeping.save_state, args)
-            for args in [
-                (self.model, "model.pt", "_initial"),
-                (self.optimizer, "optimizer.pt", "_initial"),
-                (self.scheduler, "scheduler.pt", "_initial"),
-                (self.model, "model.pt", "_best"),
-                (self.optimizer, "optimizer.pt", "_best"),
-                (self.scheduler, "scheduler.pt", "_best"),
-            ]
+        save_tasks = [
+            (self.model, "model.pt", "_initial"),
+            (self.optimizer, "optimizer.pt", "_initial"),
+            (self.scheduler, "scheduler.pt", "_initial"),
+            (self.model, "model.pt", "_best"),
+            (self.optimizer, "optimizer.pt", "_best"),
+            (self.scheduler, "scheduler.pt", "_best"),
         ]
+        for task in save_tasks:
+            spawn_thread(self.bookkeeping.save_audobject, task)
 
         # ? Load and Save Preprocessing Pipeline if specified
         _preprocess_pipe = SmartCompose([])
@@ -255,17 +254,16 @@ class ModularTaskTrainer:
                 ]
             )
 
-        [
-            spawn_thread(self.bookkeeping.save_audobject, args)
-            for args in [
-                (self.data.target_transform, "target_transform.yaml"),
-                (self.model, "model.yaml"),
-                (self.data.test_transform, "inference_transform.yaml"),
-                (self.data.file_handler, "file_handler.yaml"),
-                (_preprocess_pipe, "preprocess_pipeline.yaml"),
-                (_file_handler, "preprocess_file_handler.yaml"),
-            ]
+        save_tasks = [
+            (self.data.target_transform, "target_transform.yaml"),
+            (self.model, "model.yaml"),
+            (self.data.test_transform, "inference_transform.yaml"),
+            (self.data.file_handler, "file_handler.yaml"),
+            (_preprocess_pipe, "preprocess_pipeline.yaml"),
+            (_file_handler, "preprocess_file_handler.yaml"),
         ]
+        for task in save_tasks:
+            spawn_thread(self.bookkeeping.save_audobject, task)
 
         # ? Create Timers
         self.train_timer = Timer(output_directory, "train")

--- a/autrainer/training/training.py
+++ b/autrainer/training/training.py
@@ -57,9 +57,6 @@ class ModularTaskTrainer:
             run_name: Run name for the run. If None, the name is automatically
                 set based on the output directory. Defaults to None.
         """
-        import time
-
-        ts = time.perf_counter()
         self._cfg = cfg
         self._cfg.criterion = self._cfg.dataset.pop("criterion")
 
@@ -350,8 +347,6 @@ class ModularTaskTrainer:
             )
         else:
             self.train_tracker = None
-
-        print(f"Time to initialize trainer: {time.perf_counter() - ts}")
 
     def train(self) -> float:
         """Train the model.


### PR DESCRIPTION
This outsources the following I/O related tasks during startup to separate threads to speed up the trainer:
- saving the `requirements.txt`
- generating and saving the model summary
- saving the initial (and initial) best states for the model, optimizer, and scheduler
- saving all audobject YAML files like the model, the target transform, ...

This was a long needed improvement and i measured ~4-6x speedups of the `__init__` function.