### PR TITLE
Fix ToyDataset Initialization Order

### DIFF
--- a/autrainer/datasets/toy_dataset.py
+++ b/autrainer/datasets/toy_dataset.py
@@ -143,6 +143,7 @@ class ToyDataset(AbstractDataset):
             test_transform=test_transform,
             stratify=None,
         )
+        self._mock_df  # required due to super().__init__ with placeholders
 
     @staticmethod
     def _assert_splits(dev_split: int, test_split: float) -> None:


### PR DESCRIPTION
This fixes a small bug where a dataframe had to be accessed first to set some required parameters, like the proper target column etc.

Since the `super().__init__` call is made with placeholders, this is required to be instantly corrected before the dataset instance is available to the user.