### PR TITLE
Fix Device Fallback if not Compiled with Cuda

### DIFF
--- a/autrainer/core/utils/hardware.py
+++ b/autrainer/core/utils/hardware.py
@@ -110,7 +110,7 @@ def set_device(device_name: str) -> torch.device:
     try:
         device = torch.device(device_name)
         torch.tensor(1).to(device)
-    except RuntimeError:
+    except (RuntimeError, AssertionError):
         device = torch.device("cpu")
         logging.warning(
             f"Device '{device_name}' is not available. Falling back to CPU.",


### PR DESCRIPTION
Small fix that properly handles when torch is not compiled with cuda. If the requested device is not available, a `RuntimeError` is thrown. However, if torch is not compiled with cuda at all, an `AssertionError` is thrown.