### PR TITLE
Remove Checkpoint Attributes from Model Config during Fetching

### DIFF
--- a/autrainer/core/scripts/fetch_script.py
+++ b/autrainer/core/scripts/fetch_script.py
@@ -73,6 +73,10 @@ class FetchScript(AbstractPreprocessScript):
         for name, model in self.models.items():
             print(f" - {name}")
             model.pop("transform", None)
+            model.pop("model_checkpoint", None)
+            model.pop("optimizer_checkpoint", None)
+            model.pop("scheduler_checkpoint", None)
+            model.pop("skip_last_layer", None)
             autrainer.instantiate(config=model, output_dim=10)
 
 


### PR DESCRIPTION
Closes #93 by removing the checkpoint-related attributes from the model configuration which should not be passed to the model as parameters during instantiation (see [model docs](https://autrainer.github.io/autrainer/modules/models.html)).