### PR TITLE
Expand Quickstart Docs with List and Show Examples

### DIFF
--- a/autrainer/datasets/dcase_2020_t1a.py
+++ b/autrainer/datasets/dcase_2020_t1a.py
@@ -181,7 +181,7 @@ class DCASE2020Task1A(BaseClassificationDataset):
         """Split the training dataset into training and development sets
         taking into account the location.
         Data is split to include at least the `dev_split` fraction of the
-        training data in the development set, e.g. favoring the development
+        training data in the development set, e.g., favoring the development
         set and the split is not exactly `dev_split`.
 
 

--- a/docs/extensions/sphinx_lexers.py
+++ b/docs/extensions/sphinx_lexers.py
@@ -1,7 +1,15 @@
 from typing import Any, Dict
 
 from pygments.lexer import RegexLexer, bygroups
-from pygments.token import Keyword, Name, Number, Operator, String, Text
+from pygments.token import (
+    Keyword,
+    Literal,
+    Name,
+    Number,
+    Operator,
+    String,
+    Text,
+)
 from sphinx.application import Sphinx
 from sphinx.highlighting import lexers
 
@@ -33,9 +41,10 @@ class AutrainerLexer(RegexLexer):
                 bygroups(Name.Builtin, Text, Keyword),
             ),
             (r"\b(autrainer)\b", Name.Builtin),
-            (r"(--\w+)", Operator),
-            (r"(-\w+)", Operator),
-            (r"[^-\s]+", Text),
+            (r"--\w+", Operator),
+            (r"=\S+", Literal),
+            (r"-\w+", Operator),
+            (r"[^\s]+", Text),
             (r"\s+", Text),
         ]
     }

--- a/docs/source/development/reproducibility_guide.rst
+++ b/docs/source/development/reproducibility_guide.rst
@@ -38,7 +38,7 @@ All configuration files (not provided by `autrainer` or overridden) should be st
 directory and published alongside the :file:`conf/config.yaml` file.
 To ensure reproducibility on any system, it is recommended to solely use relative paths in the configuration files.
 
-Custom configuration files (e.g. custom models or datasets) should be placed in the :attr:`conf/` directory.
+Custom configuration files (e.g., custom models or datasets) should be placed in the :attr:`conf/` directory.
 The implementation of these configurations or further processing scripts should be placed in the :attr:`src/`
 directory or in the root directory of the project.
 

--- a/docs/source/examples/quickstart/config_dataset_path.yaml
+++ b/docs/source/examples/quickstart/config_dataset_path.yaml
@@ -1,0 +1,21 @@
+id: DCASE2016Task1-32k
+_target_: autrainer.datasets.DCASE2016Task1
+
+fold: 1
+
+path: /some/custom/path # modify the default save path
+features_subdir: log_mel_32k
+index_column: filename
+target_column: scene_label
+file_type: npy
+file_handler: autrainer.datasets.utils.NumpyFileHandler
+
+criterion: autrainer.criterions.BalancedCrossEntropyLoss
+metrics:
+  - autrainer.metrics.Accuracy
+  - autrainer.metrics.UAR
+  - autrainer.metrics.F1
+tracking_metric: autrainer.metrics.Accuracy
+
+transform:
+  type: grayscale

--- a/docs/source/modules/training.rst
+++ b/docs/source/modules/training.rst
@@ -49,7 +49,7 @@ Trainer
 It instantiates the model, dataset, criterion, optimizer, scheduler, and callbacks, and trains the model on the dataset.
 It also logs the training process and saves the model, optimizer, and scheduler states at the end of each epoch.
 
-The :attr:`cfg` of the trainer is the composed main configuration file (e.g. :file:`conf/config.yaml`) for each training configuration in the sweep.
+The :attr:`cfg` of the trainer is the composed main configuration file (e.g., :file:`conf/config.yaml`) for each training configuration in the sweep.
 
 .. autoclass:: autrainer.training.ModularTaskTrainer
    :members: train

--- a/docs/source/modules/transforms.rst
+++ b/docs/source/modules/transforms.rst
@@ -117,9 +117,9 @@ Model and dataset configurations specify the transforms to be applied to the inp
 Each :attr:`transform` configuration includes a :attr:`type` attribute, specifying the type of data the model expects or the dataset provides:
 
 * :attr:`image`: RGB images
-* :attr:`grayscale`: Grayscale images (e.g. spectrograms or other single-channel images)
+* :attr:`grayscale`: Grayscale images (e.g., spectrograms or other single-channel images)
 * :attr:`raw`: Raw audio waveforms
-* :attr:`tabular`: Tabular data (e.g. openSMILE features)
+* :attr:`tabular`: Tabular data (e.g., openSMILE features)
 
 .. note::
    The conversion between RGB and grayscale images is handled automatically by the pipeline to ensure compatibility between models and datasets.

--- a/docs/source/usage/cli_reference.rst
+++ b/docs/source/usage/cli_reference.rst
@@ -109,7 +109,7 @@ To avoid race conditions when using :ref:`hydra_launcher_plugins` that may run m
 :ref:`autrainer fetch <cli_autrainer_fetch>` and :ref:`autrainer preprocess <cli_autrainer_preprocess>` allow for
 downloading and :ref:`preprocessing <preprocessing_transforms>` of :ref:`datasets` (and pretrained model states) before training.
 
-Both commands are based on the :ref:`main configuration <main_configuration>` file (e.g. :file:`conf/config.yaml`),
+Both commands are based on the :ref:`main configuration <main_configuration>` file (e.g., :file:`conf/config.yaml`),
 such that the specified models and datasets are fetched and preprocessed accordingly.
 If a model or dataset is already fetched or preprocessed, it will be skipped.
 
@@ -156,7 +156,7 @@ Training
 --------
 
 Training is managed by :ref:`autrainer train <cli_autrainer_train>`, which starts the training process
-based on the :ref:`main configuration <main_configuration>` file (e.g. :file:`conf/config.yaml`).
+based on the :ref:`main configuration <main_configuration>` file (e.g., :file:`conf/config.yaml`).
 
 .. _cli_autrainer_train:
 
@@ -191,13 +191,13 @@ This syntax consists of the following components:
 
 * :code:`hf`: The Hugging Face Hub prefix indicating that the model is fetched from the Hugging Face Hub.
 * :code:`repo_id`: The repository ID of the model consisting of the user name and the model card name separated by a slash
-  (e.g. :code:`autrainer/example`).
-* :code:`revision` (`optional`): The revision as a commit hash, branch name, or tag name (e.g. :code:`main`).
+  (e.g., :code:`autrainer/example`).
+* :code:`revision` (`optional`): The revision as a commit hash, branch name, or tag name (e.g., :code:`main`).
   If not specified, the latest revision is used.
-* :code:`subdir` (`optional`): The subdirectory of the repository containing the model directory (e.g. :code:`AudioModel`).
+* :code:`subdir` (`optional`): The subdirectory of the repository containing the model directory (e.g., :code:`AudioModel`).
   If not specified, the model directory is automatically inferred.
   If multiple models are present in the :code:`repo_id`, :code:`subdir` must be specified, as the correct model cannot be automatically inferred.
-* :code:`local_dir` (`optional`): The local directory to which the model is downloaded to (e.g. :code:`.hf_local`).
+* :code:`local_dir` (`optional`): The local directory to which the model is downloaded to (e.g., :code:`.hf_local`).
   If not specified, the model is placed in the
   `torch hub cache directory <https://pytorch.org/docs/stable/hub.html#where-are-my-downloaded-models-saved>`_.
 
@@ -214,7 +214,7 @@ the following :ref:`autrainer inference <cli_autrainer_inference>` CLI command c
       To access private repositories, the environment variable :code:`HF_HOME` should point to the
       `Hugging Face User Access Token <https://huggingface.co/docs/hub/security-tokens>`_.
 
-      To use a custom endpoint (e.g. for a `self-hosted hub <https://huggingface.co/enterprise>`_),
+      To use a custom endpoint (e.g., for a `self-hosted hub <https://huggingface.co/enterprise>`_),
       the environment variable :code:`HF_ENDPOINT` should point to the desired endpoint URL.
 
 

--- a/docs/source/usage/cli_wrapper.rst
+++ b/docs/source/usage/cli_wrapper.rst
@@ -53,7 +53,7 @@ To avoid race conditions when using :ref:`hydra_launcher_plugins` that may run m
 :meth:`~autrainer.cli.fetch` and :meth:`~autrainer.cli.preprocess` allow for
 downloading and :ref:`preprocessing <preprocessing_transforms>` of :ref:`datasets` (and pretrained model states) before training.
 
-Both commands are based on the :ref:`main configuration <main_configuration>` file (e.g. :file:`conf/config.yaml`),
+Both commands are based on the :ref:`main configuration <main_configuration>` file (e.g., :file:`conf/config.yaml`),
 such that the specified models and datasets are fetched and preprocessed accordingly.
 If a model or dataset is already fetched or preprocessed, it will be skipped.
 
@@ -72,7 +72,7 @@ Training
 --------
 
 Training is managed by :meth:`~autrainer.cli.train`, which starts the training process
-based on the :ref:`main configuration <main_configuration>` file (e.g. :file:`conf/config.yaml`).
+based on the :ref:`main configuration <main_configuration>` file (e.g., :file:`conf/config.yaml`).
 
 
 .. _cli_wrapper_autrainer_train:
@@ -95,13 +95,13 @@ This syntax consists of the following components:
 
 * :code:`hf`: The Hugging Face Hub prefix indicating that the model is fetched from the Hugging Face Hub.
 * :code:`repo_id`: The repository ID of the model consisting of the user name and the model card name separated by a slash
-  (e.g. :code:`autrainer/example`).
-* :code:`revision` (`optional`): The revision as a commit hash, branch name, or tag name (e.g. :code:`main`).
+  (e.g., :code:`autrainer/example`).
+* :code:`revision` (`optional`): The revision as a commit hash, branch name, or tag name (e.g., :code:`main`).
   If not specified, the latest revision is used.
-* :code:`subdir` (`optional`): The subdirectory of the repository containing the model directory (e.g. :code:`AudioModel`).
+* :code:`subdir` (`optional`): The subdirectory of the repository containing the model directory (e.g., :code:`AudioModel`).
   If not specified, the model directory is automatically inferred.
   If multiple models are present in the :code:`repo_id`, :code:`subdir` must be specified, as the correct model cannot be automatically inferred.
-* :code:`local_dir` (`optional`): The local directory to which the model is downloaded to (e.g. :code:`.hf_local`).
+* :code:`local_dir` (`optional`): The local directory to which the model is downloaded to (e.g., :code:`.hf_local`).
   If not specified, the model is placed in the
   `torch hub cache directory <https://pytorch.org/docs/stable/hub.html#where-are-my-downloaded-models-saved>`_.
 
@@ -125,7 +125,7 @@ the following :meth:`~autrainer.cli.inference` CLI wrapper function can be used:
       To access private repositories, the environment variable :code:`HF_HOME` should point to the
       `Hugging Face User Access Token <https://huggingface.co/docs/hub/security-tokens>`_.
 
-      To use a custom endpoint (e.g. for a `self-hosted hub <https://huggingface.co/enterprise>`_),
+      To use a custom endpoint (e.g., for a `self-hosted hub <https://huggingface.co/enterprise>`_),
       the environment variable :code:`HF_ENDPOINT` should point to the desired endpoint URL.
 
 To use a local model path, the following :meth:`~autrainer.cli.inference` CLI wrapper function can be used:

--- a/docs/source/usage/hydra_configurations.rst
+++ b/docs/source/usage/hydra_configurations.rst
@@ -26,8 +26,8 @@ The main configuration file defines the following parameters:
 * :attr:`experiment_id`: The ID of the experiment.
 * :attr:`hydra/sweeper/params`: The parameters of the sweep.
 
-  * :attr:`\<attr\>`: An attribute to sweep over from the :ref:`defaults_list` (with comma-separated values, e.g. a list of models).
-  * :attr:`+\<attr\>`: An attribute to sweep over that is not in the :ref:`defaults_list` (with comma-separated values, e.g. a list of batch sizes).
+  * :attr:`\<attr\>`: An attribute to sweep over from the :ref:`defaults_list` (with comma-separated values, e.g., a list of models).
+  * :attr:`+\<attr\>`: An attribute to sweep over that is not in the :ref:`defaults_list` (with comma-separated values, e.g., a list of batch sizes).
 * :attr:`hydra/sweeper/filters`: A list of filters to filter out unwanted hyperparameter combinations (see :ref:`hydra_sweeper_plugins`).
 
 
@@ -61,7 +61,7 @@ Configuration Directories
 -------------------------
 
 Configuration files imported through the :ref:`defaults_list` are stored in the :file:`conf/` directory.
-The configuration files are organized in subdirectories (e.g. :file:`conf/dataset/`, :file:`conf/model/`, :file:`conf/optimizer/`, etc.).
+The configuration files are organized in subdirectories (e.g., :file:`conf/dataset/`, :file:`conf/model/`, :file:`conf/optimizer/`, etc.).
 This directory structure tells Hydra where to look for the configuration files.
 The following configuration subdirectories are available:
 
@@ -81,7 +81,7 @@ Creating Configurations
 
 `autrainer` provides a number of default configurations for models, datasets, optimizers, etc.
 that can be used out of the box without creating custom configurations.
-To use a default configuration e.g. a `MobileNetV3-Large-T` model, add it to the :file:`conf/config.yaml` file:
+To use a default configuration e.g., a `MobileNetV3-Large-T` model, add it to the :file:`conf/config.yaml` file:
 
 .. code-block:: yaml
    :linenos:
@@ -149,7 +149,7 @@ For more information on how to create custom models, see :ref:`models`.
 Shorthand Syntax
 ----------------
 
-For configurations that are not primitive types (e.g. numbers or strings) and are not included in the :ref:`defaults_list`,
+For configurations that are not primitive types (e.g., numbers or strings) and are not included in the :ref:`defaults_list`,
 shorthand syntax is used to reduce the number of configuration files required.
 Instead of a configuration file, shorthand syntax configurations can be either a string or a dictionary.
 
@@ -226,7 +226,7 @@ Optional Defaults and Overrides
 
 Optional defaults like :attr:`scheduler` and :attr:`augmentation` are set to :attr:`None`
 by default and not required to be defined in the main configuration.
-:attr:`None` is a special value that tells Hydra to ignore the default and e.g. not use a :ref:`scheduler <schedulers>`
+:attr:`None` is a special value that tells Hydra to ignore the default and e.g., not use a :ref:`scheduler <schedulers>`
 or :ref:`augmentation <augmentations>` for training.
 
 Optional defaults which are not overridden in the :attr:`hydra/sweeper/params` configuration, can be overridden using the :attr:`override`

--- a/docs/source/usage/quickstart.rst
+++ b/docs/source/usage/quickstart.rst
@@ -171,7 +171,7 @@ For the :class:`~autrainer.models.Cnn10` model, the following configuration is u
    :configs: Cnn10-32k-T
    :exact:
 
-The ending :attr:`32k-T` indicates that the model using transfer learning and has been pretrained with a sample rate of 32 kHz.
+The ending :attr:`32k-T` indicates that the model uses transfer learning and has been pretrained with a sample rate of 32 kHz.
 
 .. tip::
    

--- a/docs/source/usage/quickstart.rst
+++ b/docs/source/usage/quickstart.rst
@@ -94,7 +94,7 @@ Now, run the following :ref:`training <cli_training>` command to train the model
 Grid Search Configuration
 -------------------------
 
-To perform a grid search over multiple multiple configurations defined in the :attr:`params`, update the
+To perform a grid search over multiple configurations defined in the :attr:`params`, update the
 :ref:`main configuration <main_configuration>` (:file:`conf/config.yaml`) to include multiple values separated by a comma.
 
 The following configuration performs a grid search over the default :class:`~autrainer.models.FFNN` model with 2 and 3 hidden layers

--- a/docs/source/usage/quickstart.rst
+++ b/docs/source/usage/quickstart.rst
@@ -222,6 +222,36 @@ Now, run the following :ref:`training <cli_training>` command to train the model
     autrainer train
 
 
+.. _quick_overriding_configurations:
+
+Overriding Configurations
+-------------------------
+
+All `autrainer` default configurations can be easily overridden by creating a new configuration file in the corresponding
+directory with the same name as the default configuration.
+The new configuration file will be used instead of the default configuration.
+
+To override the default :attr:`path` the :class:`~autrainer.datasets.DCASE2016Task1` dataset stores files in, the following
+:ref:`configuration management <cli_configuration_management>` command is used to locally save the default configuration:
+
+.. code-block:: autrainer
+
+    autrainer show dataset DCASE2016Task1-32k --save
+
+Alternatively, use the following :ref:`configuration management <cli_wrapper_configuration_management>` CLI wrapper function:
+
+.. code-block:: python
+
+    autrainer.cli.show("dataset", "DCASE2016Task1-32k", save=True)
+
+This will save the default configuration to the :file:`conf/dataset/DCASE2016Task1-32k.yaml` file, which can be edited to override the :attr:`path`:
+
+.. literalinclude:: ../examples/quickstart/config_dataset_path.yaml
+   :language: yaml
+   :caption: conf/dataset/DCASE2016Task1-32k.yaml
+   :linenos:
+
+
 .. _quick_training_configurations:
 
 Training Duration & Step-based Training

--- a/docs/source/usage/quickstart.rst
+++ b/docs/source/usage/quickstart.rst
@@ -150,6 +150,20 @@ update the :ref:`main configuration <main_configuration>` (:file:`conf/config.ya
    :caption: conf/config.yaml
    :linenos:
 
+The following :ref:`configuration management <cli_configuration_management>` command is used to discover all available
+default configurations for the :class:`~autrainer.models.Cnn10` model:
+
+.. code-block:: autrainer
+
+    autrainer list model --pattern=Cnn10*
+
+Alternatively, use the following :ref:`configuration management <cli_wrapper_configuration_management>` CLI wrapper function:
+
+.. code-block:: python
+
+    autrainer.cli.list("model", pattern="Cnn10*")
+
+
 For the :class:`~autrainer.models.Cnn10` model, the following configuration is used:
 
 .. configurations::

--- a/docs/source/usage/quickstart.rst
+++ b/docs/source/usage/quickstart.rst
@@ -161,7 +161,7 @@ The ending :attr:`32k-T` indicates that the model using transfer learning and ha
 
 .. tip::
    
-   To discover all available default configurations for e.g. different models,
+   To discover all available default configurations for e.g., different models,
    the :ref:`configuration management CLI <cli_configuration_management>`,
    the :ref:`configuration management CLI wrapper <cli_wrapper_configuration_management>`,
    and the :ref:`models documentation <models>` can be used.


### PR DESCRIPTION
Closes #81 by outlining the workflow from config creation, over discovery, to overriding local configurations (e.g., with a custom dataset path) in the autrainer quickstart.

Also fixes the following minor bugs:
- `e.g.,` was written without a comma in lots of places
- the lexer for autrainer commands did not handle dashes or equals very well, leading to a change in highlighting