### PR TITLE
Fix/dataset dataclass

### DIFF
--- a/autrainer/augmentations/image_augmentations.py
+++ b/autrainer/augmentations/image_augmentations.py
@@ -5,12 +5,14 @@ import pandas as pd
 import torch
 from torchvision.transforms import v2
 
+from autrainer.datasets.utils import AbstractDataBatch
+
 from .abstract_augmentation import AbstractAugmentation
 
 
 if TYPE_CHECKING:  # pragma: no cover
     from autrainer.datasets import AbstractDataset
-    from autrainer.datasets.utils import AbstractDataBatch, AbstractDataItem
+    from autrainer.datasets.utils import AbstractDataItem
 
 
 class BaseMixUpCutMix(AbstractAugmentation):
@@ -50,7 +52,7 @@ class BaseMixUpCutMix(AbstractAugmentation):
             num_classes=data.output_dim, alpha=self.alpha
         )
 
-        def _collate_fn(batch: List[AbstractDataItem]) -> AbstractDataBatch:
+        def _collate_fn(batch: List["AbstractDataItem"]) -> AbstractDataBatch:
             probability = torch.rand(1, generator=self.g).item()
             batched: AbstractDataBatch = default(batch)
             if probability < self.p:

--- a/autrainer/core/utils/bookkeeping.py
+++ b/autrainer/core/utils/bookkeeping.py
@@ -15,7 +15,7 @@ from autrainer.metrics import AbstractMetric
 from autrainer.models.utils import create_model_inputs
 
 
-if TYPE_CHECKING:
+if TYPE_CHECKING:  # pragma: no cover
     from autrainer.datasets.utils import DataItem, DatasetWrapper
 
 

--- a/autrainer/core/utils/bookkeeping.py
+++ b/autrainer/core/utils/bookkeeping.py
@@ -12,11 +12,11 @@ from torchinfo import summary
 import yaml
 
 from autrainer.metrics import AbstractMetric
-from autrainer.training.utils import create_model_inputs
+from autrainer.models.utils import create_model_inputs
 
 
 if TYPE_CHECKING:
-    from autrainer.datasets import AbstractDataset  # pragma: no cover
+    from autrainer.datasets.utils import DataItem, DatasetWrapper
 
 
 class Bookkeeping:
@@ -105,22 +105,20 @@ class Bookkeeping:
     def save_model_summary(
         self,
         model: torch.nn.Module,
-        dataset: "AbstractDataset",
+        dataset: Union[List["DataItem"], "DatasetWrapper"],
         filename: str,
     ) -> None:
         """Save a model summary to a file.
 
         Args:
             model: Model to summarize.
-            dataset: Dataset to get the input size from.
+            dataset: Data to get the input sizes from.
+                Either a batch or a list of data points
             filename: Name of the file to save the summary to.
         """
-        batch = next(iter(dataset.train_loader))
-        model_inputs = create_model_inputs(model, batch)
+        model_inputs = create_model_inputs(model, dataset[0])
         x = [
-            np.expand_dims(
-                getattr(dataset.train_dataset[0], key), axis=0
-            ).shape
+            np.expand_dims(getattr(dataset[0], key), axis=0).shape
             for key in model_inputs.keys()
         ]
 

--- a/autrainer/datasets/abstract_dataset.py
+++ b/autrainer/datasets/abstract_dataset.py
@@ -1,7 +1,7 @@
 from abc import ABC, abstractmethod
 from functools import cached_property
 import os
-from typing import Dict, List, Optional, Tuple, TypeVar, Union
+from typing import Callable, Dict, List, Optional, Tuple, TypeVar, Union
 
 from omegaconf import DictConfig
 import pandas as pd
@@ -263,6 +263,10 @@ class AbstractDataset(ABC):
         """
         return self._init_dataset(self.df_test, self.test_transform)
 
+    @property
+    def default_collate_fn(self) -> Callable:
+        return DataBatch.collate
+
     @cached_property
     def train_loader(self) -> DataLoader:
         """Get the training loader.
@@ -276,7 +280,7 @@ class AbstractDataset(ABC):
             shuffle=True,
             generator=self._generator,
             collate_fn=self.train_transform.get_collate_fn(
-                self, default=DataBatch.collate
+                self, default=self.default_collate_fn
             ),
         )
 
@@ -293,7 +297,7 @@ class AbstractDataset(ABC):
             shuffle=False,
             generator=self._generator,
             collate_fn=self.dev_transform.get_collate_fn(
-                self, default=DataBatch.collate
+                self, default=self.default_collate_fn
             ),
         )
 
@@ -310,7 +314,7 @@ class AbstractDataset(ABC):
             shuffle=False,
             generator=self._generator,
             collate_fn=self.test_transform.get_collate_fn(
-                self, default=DataBatch.collate
+                self, default=self.default_collate_fn
             ),
         )
 

--- a/autrainer/datasets/abstract_dataset.py
+++ b/autrainer/datasets/abstract_dataset.py
@@ -279,9 +279,7 @@ class AbstractDataset(ABC):
             batch_size=self.batch_size,
             shuffle=True,
             generator=self._generator,
-            collate_fn=self.train_transform.get_collate_fn(
-                self, default=self.default_collate_fn
-            ),
+            collate_fn=self.train_transform.get_collate_fn(self),
         )
 
     @cached_property
@@ -296,9 +294,7 @@ class AbstractDataset(ABC):
             batch_size=self.inference_batch_size,
             shuffle=False,
             generator=self._generator,
-            collate_fn=self.dev_transform.get_collate_fn(
-                self, default=self.default_collate_fn
-            ),
+            collate_fn=self.dev_transform.get_collate_fn(self),
         )
 
     @cached_property
@@ -313,9 +309,7 @@ class AbstractDataset(ABC):
             batch_size=self.inference_batch_size,
             shuffle=False,
             generator=self._generator,
-            collate_fn=self.test_transform.get_collate_fn(
-                self, default=self.default_collate_fn
-            ),
+            collate_fn=self.test_transform.get_collate_fn(self),
         )
 
     def get_evaluation_data(

--- a/autrainer/models/abstract_model.py
+++ b/autrainer/models/abstract_model.py
@@ -35,4 +35,15 @@ class AbstractModel(torch.nn.Module, audobject.Object, ABC):
         Returns:
             Model inputs.
         """
-        return [v.name for v in signature(self.forward).parameters.values()]
+        names = [v.name for v in signature(self.forward).parameters.values()]
+        if names[0] != "features":
+            raise NameError(
+                (
+                    f"Model {type(self).__name__} "
+                    f"does not have 'features' "
+                    f"as the first argument of its 'forward' class. "
+                    f"Its arguments are: {names}. "
+                    f"Please rewrite 'forward' method accordingly."
+                )
+            )
+        return names

--- a/autrainer/models/abstract_model.py
+++ b/autrainer/models/abstract_model.py
@@ -40,10 +40,10 @@ class AbstractModel(torch.nn.Module, audobject.Object, ABC):
             raise NameError(
                 (
                     f"Model {type(self).__name__} "
-                    f"does not have 'features' "
-                    f"as the first argument of its 'forward' class. "
+                    "does not have 'features' "
+                    "as the first argument of its 'forward' method. "
                     f"Its arguments are: {names}. "
-                    f"Please rewrite 'forward' method accordingly."
+                    "Please rewrite the 'forward' method accordingly."
                 )
             )
         return names

--- a/autrainer/models/ast_model.py
+++ b/autrainer/models/ast_model.py
@@ -56,7 +56,7 @@ class ASTModel(AbstractModel):
     def embeddings(self, x: torch.Tensor) -> torch.Tensor:
         return self.model(x).last_hidden_state.mean(1)
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        x = self.embeddings(x)
+    def forward(self, features: torch.Tensor) -> torch.Tensor:
+        x = self.embeddings(features)
         x = self.out(x)
         return x

--- a/autrainer/models/cnn_10.py
+++ b/autrainer/models/cnn_10.py
@@ -90,7 +90,7 @@ class Cnn10(AbstractModel):
     def embeddings(self, x: torch.Tensor) -> torch.Tensor:
         return self.get_embedding(x)
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        x = self.embeddings(x)
+    def forward(self, features: torch.Tensor) -> torch.Tensor:
+        x = self.embeddings(features)
         x = self.out(x)
         return x

--- a/autrainer/models/cnn_14.py
+++ b/autrainer/models/cnn_14.py
@@ -104,7 +104,7 @@ class Cnn14(AbstractModel):
     def embeddings(self, x: torch.Tensor) -> torch.Tensor:
         return self.get_embedding(x)
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        x = self.embeddings(x)
+    def forward(self, features: torch.Tensor) -> torch.Tensor:
+        x = self.embeddings(features)
         x = self.out(x)
         return x

--- a/autrainer/models/end2you.py
+++ b/autrainer/models/end2you.py
@@ -345,11 +345,11 @@ class AudioRNNModel(AbstractModel):
 
         return rnn_out
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def forward(self, features: torch.Tensor) -> torch.Tensor:
         """
         Args:
-            x ((torch.Tensor) - BS x S x 1 x T)
+            features ((torch.Tensor) - BS x S x 1 x T)
         """
-        rnn_out = self.embeddings(x)
+        rnn_out = self.embeddings(features)
         output = self.linear(rnn_out)
         return output

--- a/autrainer/models/ffnn.py
+++ b/autrainer/models/ffnn.py
@@ -52,7 +52,7 @@ class FFNN(AbstractModel):
     def embeddings(self, x: torch.Tensor) -> torch.Tensor:
         return self._embedding_extractor(x)
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
+    def forward(self, features: torch.Tensor) -> torch.Tensor:
         for layer in self.children():
-            x = layer(x)
-        return x
+            features = layer(features)
+        return features

--- a/autrainer/models/leaf.py
+++ b/autrainer/models/leaf.py
@@ -130,8 +130,8 @@ class LEAFNet(AbstractModel):
     def embeddings(self, x: torch.Tensor) -> torch.Tensor:
         return self.leaf(x)
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        x = self.leaf(x)
+    def forward(self, features: torch.Tensor) -> torch.Tensor:
+        x = self.leaf(features)
         x = x.unsqueeze(1)
         x = self.classifier(x)
         return x

--- a/autrainer/models/sequential.py
+++ b/autrainer/models/sequential.py
@@ -43,8 +43,8 @@ class Sequential(AbstractModel):
             x = x.mean(1)
         return x
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return self.embeddings(x)
+    def forward(self, features: torch.Tensor) -> torch.Tensor:
+        return self.embeddings(features)
 
 
 class SeqFFNN(AbstractModel):
@@ -111,5 +111,5 @@ class SeqFFNN(AbstractModel):
     def embeddings(self, x: torch.Tensor) -> torch.Tensor:
         return self.backbone(x.squeeze(1))
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return self.frontend(self.embeddings(x))
+    def forward(self, features: torch.Tensor) -> torch.Tensor:
+        return self.frontend(self.embeddings(features))

--- a/autrainer/models/tdnn.py
+++ b/autrainer/models/tdnn.py
@@ -54,6 +54,6 @@ class TDNNFFNN(AbstractModel):
         embs = self.backbone(feats).squeeze(1)
         return embs
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        embs = self.embeddings(x)
+    def forward(self, features: torch.Tensor) -> torch.Tensor:
+        embs = self.embeddings(features)
         return self.frontend(embs)

--- a/autrainer/models/timm_wrapper.py
+++ b/autrainer/models/timm_wrapper.py
@@ -43,5 +43,5 @@ class TimmModel(AbstractModel):
     def embeddings(self, x: torch.Tensor) -> torch.Tensor:
         return self._embedding_extractor(x)
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return self.model(x)
+    def forward(self, features: torch.Tensor) -> torch.Tensor:
+        return self.model(features)

--- a/autrainer/models/torchvision_wrapper.py
+++ b/autrainer/models/torchvision_wrapper.py
@@ -83,5 +83,5 @@ class TorchvisionModel(AbstractModel):
     def embeddings(self, x: torch.Tensor) -> torch.Tensor:
         return self._embedding_extractor(x)
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return self.model(x)
+    def forward(self, features: torch.Tensor) -> torch.Tensor:
+        return self.model(features)

--- a/autrainer/models/utils.py
+++ b/autrainer/models/utils.py
@@ -1,10 +1,13 @@
 import os
-from typing import Callable, List
+from typing import Callable, Dict, List, Union
 import warnings
 
 import requests
 import torch
 import torch.nn.functional as F
+
+from autrainer.datasets.utils import AbstractDataBatch, DataItem
+from autrainer.models import AbstractModel
 
 
 def _download_weights(url: str, destination: str) -> None:
@@ -185,3 +188,15 @@ class ExtractLayerEmbeddings:
         self.model(x)
         self._unregister()
         return self._embeddings
+
+
+def create_model_inputs(
+    model: AbstractModel,
+    data: Union[AbstractDataBatch, DataItem],
+) -> Dict[str, torch.Tensor]:
+    _forbidden = ["features", "target", "index"]
+    model_inputs = {model.inputs[0]: data.features}
+    for key, value in vars(data).items():
+        if key not in _forbidden and key in model.inputs:
+            model_inputs[key] = value
+    return model_inputs

--- a/autrainer/models/whisper.py
+++ b/autrainer/models/whisper.py
@@ -23,8 +23,8 @@ class WhisperBackbone(AbstractModel):
         ][:, 0, :]
         return x
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return self.embeddings(x)
+    def forward(self, features: torch.Tensor) -> torch.Tensor:
+        return self.embeddings(features)
 
 
 class WhisperFFNN(AbstractModel):
@@ -64,5 +64,5 @@ class WhisperFFNN(AbstractModel):
     def embeddings(self, x: torch.Tensor) -> torch.Tensor:
         return self.backbone(x)
 
-    def forward(self, x: torch.Tensor) -> torch.Tensor:
-        return self.frontend(self.embeddings(x))
+    def forward(self, features: torch.Tensor) -> torch.Tensor:
+        return self.frontend(self.embeddings(features))

--- a/autrainer/optimizers/sam.py
+++ b/autrainer/optimizers/sam.py
@@ -5,7 +5,7 @@ import torch
 import autrainer
 from autrainer.datasets.utils import AbstractDataBatch
 from autrainer.models import AbstractModel
-from autrainer.training.utils import create_model_inputs
+from autrainer.models.utils import create_model_inputs
 
 
 class SAM(torch.optim.Optimizer):

--- a/autrainer/training/training.py
+++ b/autrainer/training/training.py
@@ -158,7 +158,7 @@ class ModularTaskTrainer:
             )
 
         self.bookkeeping.save_model_summary(
-            self.model, self.data.train_dataset, "model_summary.txt"
+            self.model, self.data, "model_summary.txt"
         )
 
         # ? Load Optimizer

--- a/autrainer/training/training.py
+++ b/autrainer/training/training.py
@@ -27,13 +27,13 @@ from autrainer.datasets.utils import (
 )
 from autrainer.loggers import AbstractLogger
 from autrainer.models import AbstractModel
+from autrainer.models.utils import create_model_inputs
 from autrainer.transforms import SmartCompose, TransformManager
 
 from .callback_manager import CallbackManager
 from .continue_training import ContinueTraining
 from .outputs_tracker import OutputsTracker, init_trackers
 from .utils import (
-    create_model_inputs,
     disaggregated_evaluation,
     format_results,
     load_pretrained_model_state,
@@ -158,7 +158,7 @@ class ModularTaskTrainer:
             )
 
         self.bookkeeping.save_model_summary(
-            self.model, self.data, "model_summary.txt"
+            self.model, self.data.train_dataset, "model_summary.txt"
         )
 
         # ? Load Optimizer

--- a/autrainer/training/utils.py
+++ b/autrainer/training/utils.py
@@ -6,9 +6,7 @@ import pandas as pd
 import torch
 import torch.nn.common_types
 
-from autrainer.datasets.utils import AbstractDataBatch
 from autrainer.metrics import AbstractMetric
-from autrainer.models import AbstractModel
 
 
 def disaggregated_evaluation(
@@ -154,15 +152,3 @@ def load_checkpoint(checkpoint: str) -> Dict[str, torch.Tensor]:
     if not os.path.isfile(checkpoint):
         raise FileNotFoundError(f"Checkpoint file not found: {checkpoint}")
     return torch.load(checkpoint)
-
-
-def create_model_inputs(
-    model: AbstractModel,
-    data: AbstractDataBatch,
-) -> Dict[str, torch.Tensor]:
-    _forbidden = ["features", "target", "index"]
-    model_inputs = {model.inputs[0]: data.features}
-    for key, value in vars(data).items():
-        if key not in _forbidden and key in model.inputs:
-            model_inputs[key] = value
-    return model_inputs

--- a/autrainer/transforms/smart_compose.py
+++ b/autrainer/transforms/smart_compose.py
@@ -72,29 +72,26 @@ class SmartCompose(T.Compose, audobject.Object):
         """Sort the transforms by their order attribute if present."""
         self.transforms.sort(key=lambda x: getattr(x, "order", 0))
 
-    def get_collate_fn(
-        self,
-        data: "AbstractDataset",
-        default: Callable,
-    ) -> Callable:
+    def get_collate_fn(self, data: "AbstractDataset") -> Callable:
         """Get the collate function. If no collate function is present in
         the transforms, None is returned.
         If multiple collate functions are present, the last one is used.
 
         Args:
             data: Dataset to get the collate function for.
-            default: Default collate_fn.
+                Includes a ``default_collate_fn``.
 
         Returns:
             Collate function.
         """
+        default_fn = data.default_collate_fn
         collate_fn = None
         for t in self.transforms:
             if fn := getattr(t, "get_collate_fn", None):
                 collate_fn = fn
         if collate_fn is not None:
-            return collate_fn(data, default)
-        return default
+            return collate_fn(data, default_fn)
+        return default_fn
 
     def __call__(self, x: torch.Tensor, index: int) -> torch.Tensor:
         """Apply the transforms to the input tensor.

--- a/tests/test_models.py
+++ b/tests/test_models.py
@@ -260,3 +260,20 @@ class TestExtractLayerEmbeddings:
         embeddings._unregister()
         x = torch.randn(1, 64)
         assert embeddings(x).shape == (1, 128), "Embeddings shape mismatch"
+
+
+class TestWrongArgumentModel:
+    @pytest.mark.xfail(raises=NameError)
+    def test_wrong_arguments(self) -> None:
+        class Foo(AbstractModel):
+            def __init__(self, output_dim):
+                super().__init__(output_dim)
+
+            def embeddings(self, x):
+                return super().embeddings(x)
+
+            def forward(self, x):
+                return x
+
+        bar = Foo(1)
+        bar.inputs

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -394,15 +394,15 @@ class TestSmartCompose:
         class MockDataset:
             output_dim = 10
 
+            @property
+            def default_collate_fn(x):
+                return DataBatch.collate
+
         assert (
-            sc.get_collate_fn(MockDataset(), default=DataBatch.collate)
-            is not None
+            sc.get_collate_fn(MockDataset()) is not None
         ), "Collate function should be present"
         assert (
-            (
-                sc.get_collate_fn(MockDataset(), default=DataBatch.collate)
-                == DataBatch.collate
-            )
+            (sc.get_collate_fn(MockDataset()) == DataBatch.collate)
             != has_collate_fn
         ), f"Collate function should be default: {not has_collate_fn}"
 


### PR DESCRIPTION
This provides some fixes for #61:

1. Renaming the main argument in all `AbstractModel` classes to match what the `create_model_input` func expects
2. Change `bookkeeping` to use `create_model_input` as the `save_model_summary` wouldn't work if there were more inputs
3. Added a `default_collate_fn` parameter to `AbstractDataset` to more easily allow the user to override it and specify their custom `collate_fn`

In general, I like your solution with the `signature` checking. I think it makes things more easily extensible while remaining mostly under-the-hood (it does require the user to specify `features` as the name of their model input, I think we should write a neater error message if that does not happen)

Once we merge this I can rebase #61 to `main` and put the finishing touches