### PR TITLE
Fix Preprocessing Removes Dataset Subdirectories

### DIFF
--- a/autrainer/core/scripts/preprocess_script.py
+++ b/autrainer/core/scripts/preprocess_script.py
@@ -31,7 +31,6 @@ def preprocess_main(
     num_workers: int,
     update_frequency: int,
 ):
-    import os
     from pathlib import Path
 
     import torch
@@ -102,10 +101,10 @@ def preprocess_main(
             out_path = Path(
                 features_path,
                 features_subdir,
-                os.path.basename(item_path),
-            ).with_suffix("." + output_file_type)
-            os.makedirs(os.path.dirname(out_path), exist_ok=True)
-            if os.path.exists(out_path):
+                item_path,
+            ).with_suffix(f".{output_file_type}")
+            out_path.parent.mkdir(parents=True, exist_ok=True)
+            if out_path.exists():
                 continue
             output_file_handler.save(
                 out_path, pipeline(instance[0].squeeze(dim=0), 0)

--- a/autrainer/core/scripts/preprocess_script.py
+++ b/autrainer/core/scripts/preprocess_script.py
@@ -37,6 +37,7 @@ def preprocess_main(
     import torch
     from tqdm import tqdm
 
+    from autrainer.datasets import AbstractDataset
     from autrainer.datasets.utils import AbstractFileHandler
     from autrainer.transforms import SmartCompose
 
@@ -67,7 +68,7 @@ def preprocess_main(
     features_subdir = dataset["features_subdir"]
 
     dataset["features_subdir"] = None
-    data = autrainer.instantiate(dataset)
+    data = autrainer.instantiate(dataset, instance_of=AbstractDataset)
     # manually disable dataset transforms
     data.train_transform = None
     data.dev_transform = None

--- a/autrainer/core/scripts/preprocess_script.py
+++ b/autrainer/core/scripts/preprocess_script.py
@@ -76,10 +76,10 @@ def preprocess_main(
     pipeline = SmartCompose(
         [autrainer.instantiate_shorthand(t) for t in preprocess["pipeline"]]
     )
-    for d, n in (
-        (data.train_dataset, "train"),
-        (data.dev_dataset, "dev"),
-        (data.test_dataset, "test"),
+    for d, df, n in (
+        (data.train_dataset, data.df_train, "train"),
+        (data.dev_dataset, data.df_dev, "dev"),
+        (data.test_dataset, data.df_test, "test"),
     ):
         # TODO: dataloader underutilized
         # workers only parallelize loading
@@ -96,8 +96,7 @@ def preprocess_main(
             disable=update_frequency == 0,
         ):
             # TODO: will be streamlined once we switch to dataclass
-            index = d.df.index[int(instance[2])]
-            item_path = d.df.loc[index, d.index_column]
+            item_path = df.loc[df.index[int(instance[2])], d.index_column]
             out_path = Path(
                 features_path,
                 features_subdir,

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -145,7 +145,7 @@ class TestPreprocessing(BaseIndividualTempDir):
             ),
         ],
     )
-    def test_preprocessing(
+    def test_log_mel_spectrogram_preprocessing(
         self, preprocess, sampling_rate, features_path
     ) -> None:
         self._mock_dataframes("data/TestDataset")

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -13,7 +13,7 @@ from autrainer.datasets import BaseClassificationDataset
 from .utils import BaseIndividualTempDir
 
 
-class TestBaseDatasets(BaseIndividualTempDir):
+class TestPreprocessing(BaseIndividualTempDir):
     @staticmethod
     def _mock_dataframes(
         path: str,

--- a/tests/test_preprocessing.py
+++ b/tests/test_preprocessing.py
@@ -36,9 +36,12 @@ class TestPreprocessing(BaseIndividualTempDir):
             df[target_column] = [i % 10 for i in range(num_files)]
         elif target_type == "regression":
             df[target_column] = [i for i in range(num_files)]
-        else:
+        elif target_type in ["ml-classification", "mt-regression"]:
             for i in range(10):
                 df[f"target_{i}"] = torch.randint(0, 2, (num_files,)).tolist()
+        else:
+            msg = f"Target type '{target_type}' not implemented."
+            raise NotImplementedError(msg)
 
         output_files = output_files or ["train", "dev", "test"]
         for output_file in output_files:


### PR DESCRIPTION
Closes #104 by keeping potential subdirectories in the `features_subdir` / `audio_subdir` of the dataset unchanged during preprocessing.

I think i now understood how the `os.path.basename` call ended up here, the function previously accessed the `DatasetWrapper` dataframe which automatically resolves the file paths on instantiation: https://github.com/autrainer/autrainer/blob/9710ced605df0b6550f85f858fb58ac5a86c359e/autrainer/datasets/utils/dataset_wrapper.py#L58-L62

Therefore i switched to use the (correct) public `df_train` etc. dataframes of the actual dataset class which should have been used in the first place.

Also added test coverage for nested files and improved the readability here and there.