### PR TITLE
Fix unsafe Matplotlib Backends if Threads are used

### DIFF
--- a/autrainer/core/utils/__init__.py
+++ b/autrainer/core/utils/__init__.py
@@ -1,9 +1,9 @@
 from .bookkeeping import Bookkeeping
 from .hardware import (
+    ThreadManager,
     get_hardware_info,
     save_hardware_info,
     set_device,
-    spawn_thread,
 )
 from .requirements import save_requirements
 from .set_seed import set_seed
@@ -19,6 +19,6 @@ __all__ = [
     "set_device",
     "set_seed",
     "silence",
-    "spawn_thread",
+    "ThreadManager",
     "Timer",
 ]

--- a/tests/test_core_utils.py
+++ b/tests/test_core_utils.py
@@ -3,6 +3,7 @@ import os
 import random
 import time
 
+import matplotlib
 import numpy as np
 from omegaconf import OmegaConf
 import pandas as pd
@@ -16,6 +17,7 @@ from autrainer.core.constants import (
 )
 from autrainer.core.utils import (
     Bookkeeping,
+    ThreadManager,
     Timer,
     get_hardware_info,
     save_hardware_info,
@@ -23,12 +25,14 @@ from autrainer.core.utils import (
     set_device,
     set_seed,
     silence,
-    spawn_thread,
 )
 from autrainer.metrics import UAR, Accuracy
 from autrainer.models import FFNN
 
 from .utils import BaseIndividualTempDir
+
+
+matplotlib.use("Agg")
 
 
 class TestBookkeeping(BaseIndividualTempDir):
@@ -263,12 +267,15 @@ class TestHardware(BaseIndividualTempDir):
             in caplog.text
         ), "Should log warning."
 
+
+class TestThreadManager:
     def test_spawning_thread(self, capsys: pytest.CaptureFixture) -> None:
         def test_fn(value: str) -> None:
             print(value)
 
-        spawn_thread(test_fn, ("Test",))
-        time.sleep(0.1)
+        tm = ThreadManager()
+        tm.spawn(test_fn, "Test")
+        tm.join()
         out, _ = capsys.readouterr()
         assert "Test" in out, "Should spawn thread."
 


### PR DESCRIPTION
This fixes a bug where the main loop goes out of scope and tkinter-related classes are garbage collected / deleted on a different thread by moving explicitly to `Agg` as backend iff a thread could be spawned.
After no thread can be present anymore (manager is a singleton), the backend switches back to whatever it was before to try to clash with user related stuff as little as possible.

For us, switching the backed to `Agg` changes nothing as we produce all plots in a headless fashion anyways.