### PR TITLE
Fix Callback Positioning for Loggers and Docs

### DIFF
--- a/.github/workflows/CD.yaml
+++ b/.github/workflows/CD.yaml
@@ -32,7 +32,7 @@ jobs:
       - name: Install Poetry
         uses: snok/install-poetry@v1
       - name: Install Dependencies
-        run: poetry install --with docs
+        run: poetry install --all-extras
       - name: Build Docs
         run: poetry run sphinx-build -b html docs/source docs/build
       - name: Publish to GitHub Pages
@@ -40,4 +40,3 @@ jobs:
         with:
           github_token: ${{ secrets.GITHUB_TOKEN }}
           publish_dir: docs/build
-    

--- a/.github/workflows/CI.yaml
+++ b/.github/workflows/CI.yaml
@@ -27,4 +27,3 @@ jobs:
         run: poetry install --all-extras
       - name: Run Tests
         run: poetry run pytest
-

--- a/autrainer/postprocessing/aggregate.py
+++ b/autrainer/postprocessing/aggregate.py
@@ -1,4 +1,5 @@
 from collections import defaultdict
+from copy import deepcopy
 import os
 import shutil
 from typing import List, Optional
@@ -314,7 +315,7 @@ class AggregateGrid:
         )
         for logger in loggers:
             logger.setup()
-            logger.log_params(cfg)
+            logger.log_params(deepcopy(cfg))
             logger.log_timers(
                 {
                     "time.train.mean": timers["train"]["mean"],

--- a/autrainer/training/training.py
+++ b/autrainer/training/training.py
@@ -362,6 +362,7 @@ class ModularTaskTrainer:
             self.optimizer.custom_step if custom_step else self._train_step
         )
 
+        self._thread_manager.join()
         self.callback_manager.callback(
             position="cb_on_train_begin", trainer=self
         )
@@ -431,11 +432,10 @@ class ModularTaskTrainer:
         # ? Plot Metrics
         self.plot_metrics.plot_run(self.metrics)
 
+        self.bookkeeping.save_results_df(self.metrics, "metrics.csv")
         self.callback_manager.callback(
             position="cb_on_train_end", trainer=self
         )
-        self.bookkeeping.save_results_df(self.metrics, "metrics.csv")
-        self._thread_manager.join()
         return self.metrics.loc[self.best_iteration][
             self.data.tracking_metric.name
         ]

--- a/autrainer/training/training.py
+++ b/autrainer/training/training.py
@@ -314,9 +314,9 @@ class ModularTaskTrainer:
                 self.optimizer,
                 self.scheduler,
                 self.criterion,
-                self.continue_training,
                 *self.loggers,
                 *self.callbacks,
+                self.continue_training,  # has to be last as it might overwrite other callbacks
             ]
         )
 

--- a/docs/source/modules/loggers.rst
+++ b/docs/source/modules/loggers.rst
@@ -9,7 +9,8 @@ Loggers can be added by specifying a list of :attr:`loggers` in the :ref:`main c
 
    To create custom loggers, refer to the :ref:`custom loggers tutorial <tut_loggers>`.
 
-For example, to add a :class:`MLFlowLogger`, specify it in the :ref:`main configuration <main_configuration>` by adding a list of :attr:`loggers`:
+For example, to add a :class:`~autrainer.loggers.MLFlowLogger`,
+specify it in the :ref:`main configuration <main_configuration>` by adding a list of :attr:`loggers`:
 
 .. code-block:: yaml
    :caption: conf/config.yaml
@@ -24,7 +25,7 @@ For example, to add a :class:`MLFlowLogger`, specify it in the :ref:`main config
 Abstract Logger
 ---------------
 
-All loggers inherit from the :class:`AbstractLogger` class.
+All loggers inherit from the :class:`~autrainer.loggers.AbstractLogger` class.
 
 .. autoclass:: autrainer.loggers.AbstractLogger
    :members:
@@ -33,7 +34,7 @@ All loggers inherit from the :class:`AbstractLogger` class.
 Optional Loggers
 ----------------
 
-The :class:`MLFlowLogger` logs data to MLFlow, while the :class:`TensorBoardLogger` logs data to TensorBoard.
+The :class:`~autrainer.loggers.MLFlowLogger` logs data to MLFlow, while the :class:`~autrainer.loggers.TensorBoardLogger` logs data to TensorBoard.
 Both loggers require additional dependencies, which are not installed by default.
 To install all necessary dependencies, refer to the :ref:`installation` section.
 
@@ -54,9 +55,9 @@ In both cases, the path should be the same as the :code:`output_dir` specified i
 Fallback Logger
 ---------------
 
-If a logger such as :class:`MLFlowLogger` is specified in the configuration,
+If a logger such as :class:`~autrainer.loggers.MLFlowLogger` is specified in the configuration,
 but the required dependencies are not installed,
-the :class:`FallbackLogger` will be used instead.
+the :class:`~autrainer.loggers.FallbackLogger` will be used instead.
 This logger will log a warning message and will not log any data.
 
 .. autoclass:: autrainer.loggers.FallbackLogger

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -47,6 +47,18 @@ class TestCLIIntegration(BaseIndividualTempDir):
         config["progress_bar"] = False
         config["hydra"]["sweeper"]["params"]["dataset"] = dataset
         config["hydra"]["sweeper"]["params"]["model"] = model
+        config["loggers"] = [
+            {
+                "autrainer.loggers.MLFlowLogger": {
+                    "output_dir": "${results_dir}/.mlflowruns"
+                },
+            },
+            {
+                "autrainer.loggers.TensorBoardLogger": {
+                    "output_dir": "${results_dir}/.tensorboard"
+                },
+            },
+        ]
         OmegaConf.save(config, "conf/config.yaml")
         self._train_postprocess(capfd)
 


### PR DESCRIPTION
This is a collection of multiple small bugfixes related to our loggers:
- the file saving-related threads need to be joined before `cb_on_train_begin`, as loggers (and other stuff) can access these (this is the first callback)
- same goes with saving the `metrics.csv`, this has to be done before `cb_on_train_end`
- the continue training callback has to be last in the callback order such that it can replay potential loggers etc.
- during aggregation, we replay the newly created run which potentially modifies the params passed to it, so we need to copy them properly
- added mlflow and tensorboard loggers to tests to catch this behavior in the future
- added full class paths to the logger docs such that they are properly resolved to internal links
- install all extras in the CD pipeline when building the docs such that optional documentation is properly rendered and not the fallback behavior, see e.g., mlflow logger docs: https://autrainer.github.io/autrainer/modules/loggers.html#autrainer.loggers.MLFlowLogger