### PR TITLE
Fix Redundant Disaggregated Evaluation Calculation

### DIFF
--- a/autrainer/training/training.py
+++ b/autrainer/training/training.py
@@ -716,16 +716,22 @@ class ModularTaskTrainer:
                     iteration,
                 )
             )
-
-        logging_results = disaggregated_evaluation(
-            targets=tracker.targets,
-            predictions=tracker.predictions,
-            indices=tracker.indices,
-            groundtruth=df,
-            metrics=self.data.metrics,
-            target_column=self.data.target_column,
-            stratify=self.data.stratify,
-        )
+        if self.data.stratify or isinstance(self.data.target_column, list):
+            logging_results = disaggregated_evaluation(
+                targets=tracker.targets,
+                predictions=tracker.predictions,
+                indices=tracker.indices,
+                groundtruth=df,
+                metrics=self.data.metrics,
+                target_column=self.data.target_column,
+                stratify=self.data.stratify,
+            )
+        else:
+            logging_results = {
+                k: {"all": v}
+                for k, v in results.items()
+                if not k.endswith("loss")
+            }
         if dev_evaluation:
             logging_results["dev_loss"] = {"all": results["dev_loss"]}
             logging_results["iteration"] = iteration


### PR DESCRIPTION
Disaggregated / stratified evaluation should be performed when either of the two cases is true:
- one or more `data.stratify` columns are present
- `data.target_column` is a list, i.e., we are doing multi-label or multi-target regression, and we want to compute the metrics per class or target
In any other case, we just compute the metrics twice which can be safely avoided by just checking if any of the above cases is present.