### PR TITLE
Added CCCLoss

### DIFF
--- a/autrainer-configurations/dataset/MSPPodcast-EmoDims-wav-ccc.yaml
+++ b/autrainer-configurations/dataset/MSPPodcast-EmoDims-wav-ccc.yaml
@@ -1,0 +1,28 @@
+# Important: should be used with inference_batch_size: 1
+id: MSPPodcast-EmoDims-wav-ccc
+_target_: autrainer.datasets.MSPPodcast
+
+path: data/MSPPodcast
+index_column: FileName
+target_column: [EmoAct,EmoVal,EmoDom]
+file_type: wav
+file_handler: autrainer.datasets.utils.AudioFileHandler
+
+criterion: autrainer.criterions.CCCLoss
+metrics:
+  - autrainer.metrics.PCC
+  - autrainer.metrics.CCC
+  - autrainer.metrics.MSE
+  - autrainer.metrics.MAE
+tracking_metric: autrainer.metrics.CCC
+
+transform:
+  type: raw
+  base:
+    - autrainer.transforms.Expand:
+        size: 48000
+        axis: -1
+  train:
+    - autrainer.transforms.RandomCrop:
+        size: 48000
+        axis: -1

--- a/autrainer/criterions/__init__.py
+++ b/autrainer/criterions/__init__.py
@@ -6,13 +6,14 @@ from .classification import (
     WeightedBCEWithLogitsLoss,
     WeightedCrossEntropyLoss,
 )
-from .regression import MSELoss, WeightedMSELoss
+from .regression import CCCLoss, MSELoss, WeightedMSELoss
 
 
 __all__ = [
     "BalancedBCEWithLogitsLoss",
     "BalancedCrossEntropyLoss",
     "BCEWithLogitsLoss",
+    "CCCLoss",
     "CrossEntropyLoss",
     "MSELoss",
     "WeightedBCEWithLogitsLoss",

--- a/docs/source/modules/criterions.rst
+++ b/docs/source/modules/criterions.rst
@@ -27,6 +27,9 @@ For more information see `this discussion <https://discuss.pytorch.org/t/dataloa
 
 `autrainer` provides the following wrappers:
 
+.. autoclass:: autrainer.criterions.CCCLoss
+   :members:
+
 .. autoclass:: autrainer.criterions.CrossEntropyLoss
    :members:
 


### PR DESCRIPTION
This PR adds the `CCCloss`. It is a similar implementation to the one used to train https://huggingface.co/audeering/wav2vec2-large-robust-12-ft-emotion-msp-dim but adapted to match the biased std/var estimations of `numpy` so it's compatible with `audmetric`