### PR TITLE
Fix too Small Dev and Test Loss Average during Tracking

### DIFF
--- a/autrainer/training/training.py
+++ b/autrainer/training/training.py
@@ -858,7 +858,7 @@ class ModularTaskTrainer:
                     batch_idx=batch_idx,
                     loss=reduced_loss,
                 )
-            losses /= len(loader) + 1
+            losses /= len(loader)
         tracker.save(iteration_folder, reset=False)
         results = {
             "loss": losses,


### PR DESCRIPTION
Closes #125 and removes the erroneous `+1` when averaging over the losses for logging.