### PR TITLE
Fix Mutable Hydra Multirun Configurations

### DIFF
--- a/autrainer-configurations/_autrainer_.yaml
+++ b/autrainer-configurations/_autrainer_.yaml
@@ -6,6 +6,8 @@ defaults:
   - scheduler: None
   - augmentation: None
   - plotting: Default
+  - /hydra/callbacks:
+      - ConfigDirSnapshot
   - override hydra/sweeper: autrainer_filter_sweeper
 
 training_type: epoch

--- a/autrainer-configurations/_autrainer_.yaml
+++ b/autrainer-configurations/_autrainer_.yaml
@@ -1,8 +1,8 @@
 defaults:
   - _self_
-  - dataset: ???
-  - model: ???
-  - optimizer: ???
+  - dataset: ToyTabular-C
+  - model: ToyFFNN
+  - optimizer: Adam
   - scheduler: None
   - augmentation: None
   - plotting: Default

--- a/autrainer-configurations/config.yaml
+++ b/autrainer-configurations/config.yaml
@@ -9,7 +9,7 @@ iterations: 5
 hydra:
   sweeper:
     params:
-      +seed: 1
+      +seed: 1,2,3,4
       +batch_size: 32
       +learning_rate: 0.001
       dataset: ToyTabular-C

--- a/autrainer-configurations/config.yaml
+++ b/autrainer-configurations/config.yaml
@@ -9,7 +9,7 @@ iterations: 5
 hydra:
   sweeper:
     params:
-      +seed: 1,2,3,4
+      +seed: 1
       +batch_size: 32
       +learning_rate: 0.001
       dataset: ToyTabular-C

--- a/autrainer-configurations/hydra/callbacks/ConfigDirSnapshot.yaml
+++ b/autrainer-configurations/hydra/callbacks/ConfigDirSnapshot.yaml
@@ -1,0 +1,5 @@
+# @package _global_
+hydra:
+  callbacks:
+    my_callback:
+      _target_: autrainer.core.wrappers.config_dir_snapshot.ConfigDirSnapshot

--- a/autrainer/core/scripts/fetch_script.py
+++ b/autrainer/core/scripts/fetch_script.py
@@ -13,6 +13,7 @@ from .abstract_preprocess_script import (
 from .utils import (
     add_hydra_args_to_sys,
     catch_cli_errors,
+    check_invalid_config_path_arg,
     run_hydra_cmd,
     running_in_notebook,
 )
@@ -50,6 +51,7 @@ class FetchScript(AbstractPreprocessScript):
             if not self._id_in_dict(self.models, cfg.model.id):
                 self.models[cfg.model.id] = OmegaConf.to_container(cfg.model)
 
+        check_invalid_config_path_arg(self.parser)
         main()
         self._download_datasets()
         self._download_models()

--- a/autrainer/core/scripts/group_script.py
+++ b/autrainer/core/scripts/group_script.py
@@ -8,6 +8,7 @@ from .abstract_script import AbstractScript, MockParser
 from .utils import (
     add_hydra_args_to_sys,
     catch_cli_errors,
+    check_invalid_config_path_arg,
     run_hydra_cmd,
     running_in_notebook,
 )
@@ -47,6 +48,7 @@ class GroupScript(AbstractScript):
 
             ma.group_runs()
 
+        check_invalid_config_path_arg(self.parser)
         main()
 
 

--- a/autrainer/core/scripts/preprocess_script.py
+++ b/autrainer/core/scripts/preprocess_script.py
@@ -13,6 +13,7 @@ from .abstract_preprocess_script import (
 from .utils import (
     add_hydra_args_to_sys,
     catch_cli_errors,
+    check_invalid_config_path_arg,
     run_hydra_cmd,
     running_in_notebook,
 )
@@ -38,7 +39,7 @@ def preprocess_main(
 
     from autrainer.core.structs import DataBatch
     from autrainer.datasets import AbstractDataset
-    from autrainer.datasets.utils import AbstractFileHandler
+    from autrainer.datasets.utils import AbstractFileHandler, DataBatch
     from autrainer.transforms import SmartCompose
 
     print(f" - {name}")
@@ -185,6 +186,7 @@ class PreprocessScript(AbstractPreprocessScript):
                     pass
             self.preprocessing[cfg.dataset.id] = preprocessing_cfg
 
+        check_invalid_config_path_arg(self.parser)
         main()
         self._preprocess_datasets()
         self._clean_up()

--- a/autrainer/core/scripts/preprocess_script.py
+++ b/autrainer/core/scripts/preprocess_script.py
@@ -39,7 +39,7 @@ def preprocess_main(
 
     from autrainer.core.structs import DataBatch
     from autrainer.datasets import AbstractDataset
-    from autrainer.datasets.utils import AbstractFileHandler, DataBatch
+    from autrainer.datasets.utils import AbstractFileHandler
     from autrainer.transforms import SmartCompose
 
     print(f" - {name}")

--- a/autrainer/core/scripts/train_script.py
+++ b/autrainer/core/scripts/train_script.py
@@ -8,6 +8,7 @@ from .abstract_script import AbstractScript, MockParser
 from .utils import (
     add_hydra_args_to_sys,
     catch_cli_errors,
+    check_invalid_config_path_arg,
     run_hydra_cmd,
     running_in_notebook,
 )
@@ -72,6 +73,7 @@ class TrainScript(AbstractScript):
             )
             return trainer.train()
 
+        check_invalid_config_path_arg(self.parser)
         main()
 
 

--- a/autrainer/core/scripts/utils.py
+++ b/autrainer/core/scripts/utils.py
@@ -144,7 +144,8 @@ def check_invalid_config_path_arg(parser: argparse.ArgumentParser) -> None:
             "The `--config-path/-cp` Hydra CLI argument is not supported "
             " by autrainer.\nTo override the config directory and name, "
             "use the `--config-dir/-cd` and `--config-name/-cn` arguments "
-            "instead.\nFor more information, refer to the Hydra documentation: "
-            "https://hydra.cc/docs/advanced/hydra-command-line-flags/"
+            "instead.\nFor more information, refer to the Hydra documentation "
+            "(https://hydra.cc/docs/advanced/hydra-command-line-flags/) and "
+            "https://github.com/autrainer/autrainer/pull/132."
         ),
     )

--- a/autrainer/core/scripts/utils.py
+++ b/autrainer/core/scripts/utils.py
@@ -1,3 +1,4 @@
+import argparse
 from functools import wraps
 import sys
 from typing import Any, Callable, Dict, Optional, TypeVar
@@ -128,3 +129,22 @@ def add_hydra_args_to_sys(
             f"{k}={v}"
             for k, v in encode_override_kwargs(override_kwargs).items()
         )
+
+
+def check_invalid_config_path_arg(parser: argparse.ArgumentParser) -> None:
+    cp_parser = argparse.ArgumentParser()
+    cp_parser.add_argument("--config-path", "-cp")
+    args, remaining = cp_parser.parse_known_args()
+    sys.argv = [sys.argv[0]] + remaining
+    if args.config_path is None:
+        return
+    raise CommandLineError(
+        parser=parser,
+        message=(
+            "The `--config-path/-cp` Hydra CLI argument is not supported "
+            " by autrainer.\nTo override the config directory and name, "
+            "use the `--config-dir/-cd` and `--config-name/-cn` arguments "
+            "instead.\nFor more information, refer to the Hydra documentation: "
+            "https://hydra.cc/docs/advanced/hydra-command-line-flags/"
+        ),
+    )

--- a/autrainer/core/utils/hardware.py
+++ b/autrainer/core/utils/hardware.py
@@ -4,7 +4,6 @@ import platform
 import threading
 from typing import Callable, Optional
 
-import matplotlib
 from omegaconf import OmegaConf
 import psutil
 import torch
@@ -22,7 +21,6 @@ class ThreadManager:
         return cls._instance
 
     def _initialize(self) -> None:
-        self._matplotlib_backend = matplotlib.get_backend()
         self._threads = []
         self._lock = threading.Lock()
 
@@ -34,7 +32,6 @@ class ThreadManager:
             args: Arguments to pass to the function.
         """
         with self._lock:
-            matplotlib.use("Agg")  # TkAgg is not thread-safe
             t = threading.Thread(target=target, args=args or ())
             t.start()
             self._threads.append(t)
@@ -51,7 +48,6 @@ class ThreadManager:
         with self._lock:
             if self._threads:
                 return
-            matplotlib.use(self._matplotlib_backend)
 
 
 def get_gpu_info(device: torch.device) -> Optional[dict]:

--- a/autrainer/core/wrappers/config_dir_snapshot.py
+++ b/autrainer/core/wrappers/config_dir_snapshot.py
@@ -1,0 +1,85 @@
+import argparse
+import logging
+import os
+from pathlib import Path
+import shutil
+import sys
+import tempfile
+from typing import Any, Optional
+
+from hydra.experimental.callback import Callback
+from omegaconf import DictConfig
+
+
+def pop_config_dir_from_argv() -> Optional[str]:
+    parser = argparse.ArgumentParser()
+    parser.add_argument("--config-dir", "-cd")
+    args, remaining = parser.parse_known_args()
+    sys.argv = [sys.argv[0]] + remaining
+    return args.config_dir
+
+
+class ConfigDirSnapshot(Callback):
+    _instance = None
+    _temp_dir: Optional[Path] = None
+
+    def __new__(cls) -> "ConfigDirSnapshot":
+        if cls._instance is None:
+            cls._instance = super().__new__(cls)
+            cls._temp_dir = None
+        return cls._instance
+
+    def create_snapshot_dir(self) -> Optional[str]:
+        """Create a snapshot of the config directory by copying all
+        configuration files to a temporary directory.
+
+        The snapshot is created by either copying the config directory
+        specified by the `--config-dir` argument (and removing it from
+        `sys.argv`) or by copying the `conf` directory in the current
+        working directory if it exists.
+        If no config directory is found, the method returns None.
+
+        Returns:
+            The path to the temporary directory containing the snapshot of
+            the config directory, or None if no config directory was found.
+        """
+        if self._temp_dir and self._temp_dir.is_dir():
+            return str(self._temp_dir)
+
+        config_dir = pop_config_dir_from_argv()
+        if config_dir is None and os.path.isdir("conf"):
+            config_dir = "conf"
+        if config_dir is None or not os.path.isdir(config_dir):
+            return None  # nothing to snapshot
+
+        config_dir = Path(config_dir).resolve()
+        self._temp_dir = Path(tempfile.mkdtemp())
+
+        for path in config_dir.rglob("*.yaml"):
+            if not path.is_file():
+                continue  # skip directories ending with .yaml
+            relative_path = path.relative_to(config_dir)
+            destination = self._temp_dir / relative_path
+            destination.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(path, destination)
+        return str(self._temp_dir)
+
+    def remove_snapshot_dir(self) -> None:
+        """Remove the temporary config directory and all its contents.
+
+        Automatically called at the end of the Hydra multirun.
+        """
+        try:
+            if self._temp_dir and self._temp_dir.is_dir():
+                shutil.rmtree(self._temp_dir)
+        except Exception as e:
+            logging.warning(f"Failed to remove temp config dir: {e}")
+        finally:
+            self._temp_dir = None  # always try to reset the temp dir
+
+    def on_multirun_end(self, config: DictConfig, **kwargs: Any) -> None:
+        """Called in MULTIRUN mode after all jobs returns.
+
+        When using a launcher, this will be executed on local machine.
+        """
+        self.remove_snapshot_dir()

--- a/autrainer/core/wrappers/main.py
+++ b/autrainer/core/wrappers/main.py
@@ -9,6 +9,8 @@ from hydra.plugins.search_path_plugin import SearchPathPlugin
 
 import autrainer
 
+from .config_dir_snapshot import ConfigDirSnapshot
+
 
 class AutrainerPathPlugin(SearchPathPlugin):
     def manipulate_search_path(self, search_path: ConfigSearchPath) -> None:
@@ -16,7 +18,8 @@ class AutrainerPathPlugin(SearchPathPlugin):
             os.path.dirname(autrainer.__path__[0]),
             "autrainer-configurations",
         )
-        search_path.append(provider="autrainer-current", path="file://conf")
+        snapshot = f"file://{ConfigDirSnapshot().create_snapshot_dir()}"
+        search_path.append(provider="autrainer-snapshot", path=snapshot)
         search_path.append(
             provider="autrainer-configs",
             path=f"file://{lib_path}",

--- a/autrainer/core/wrappers/main.py
+++ b/autrainer/core/wrappers/main.py
@@ -48,6 +48,10 @@ def main(
             search path. Defaults to None.
         version_base: Hydra version base. Defaults to None.
     """
+    if not any("jupyter" in arg or "ipykernel" in arg for arg in sys.argv):
+        import matplotlib
+
+        matplotlib.use("Agg")  # TkAgg is not thread-safe
 
     Plugins.instance().register(AutrainerPathPlugin)
     add_current_directory_to_path()

--- a/autrainer/core/wrappers/main.py
+++ b/autrainer/core/wrappers/main.py
@@ -18,8 +18,12 @@ class AutrainerPathPlugin(SearchPathPlugin):
             os.path.dirname(autrainer.__path__[0]),
             "autrainer-configurations",
         )
-        snapshot = f"file://{ConfigDirSnapshot().create_snapshot_dir()}"
-        search_path.append(provider="autrainer-snapshot", path=snapshot)
+        snapshot = ConfigDirSnapshot().create_snapshot_dir()
+        if snapshot is not None:
+            search_path.append(
+                provider="autrainer-snapshot",
+                path=f"file://{snapshot}",
+            )
         search_path.append(
             provider="autrainer-configs",
             path=f"file://{lib_path}",


### PR DESCRIPTION
Closes #113 by copying all Hydra related configurations to a temporary directory before launching the runs.
Instead of exposing the `conf` directory (or the one specified with `--config-dir/-cd`), the temporary directory is added to the Hydra directories.
This way, edits to the currently executed configuration no longer have any effect on the actual multirun.

At the same time this also fixes:
- reformatting of main configurations to no longer include placeholder (`???`) paramters; this allows running useful hydra commands that need to compose the config like `autrainer train --info`
- handle incompatible `--config-path/-cp` Hydra argument and fail if this is present
- proper handling of setting matplotlib to `Agg` backend (this got somehow triggered again; i.e., i didnt fix it properly earlier)
- move `DataBatch` to local scope otherwise all CLI commands are slower