### PR TITLE
Add Transfer Argument to Models

### DIFF
--- a/autrainer-configurations/model/ASTModel.yaml
+++ b/autrainer-configurations/model/ASTModel.yaml
@@ -1,0 +1,9 @@
+id: ASTModel
+_target_: autrainer.models.ASTModel
+
+transform:
+  type: raw
+  base:
+    - autrainer.transforms.FeatureExtractor:
+        fe_type: AST
+        fe_transfer: MIT/ast-finetuned-audioset-10-10-0.4593

--- a/autrainer-configurations/model/TDNNFFNN.yaml
+++ b/autrainer-configurations/model/TDNNFFNN.yaml
@@ -1,7 +1,6 @@
-id: TDNNFFNN-T
+id: TDNNFFNN
 _target_: autrainer.models.TDNNFFNN
 hidden_size: 32
-transfer: true
 
 transform:
   type: raw

--- a/autrainer-configurations/model/Whisper-FFNN-Base-T.yaml
+++ b/autrainer-configurations/model/Whisper-FFNN-Base-T.yaml
@@ -4,6 +4,7 @@ model_name: openai/whisper-base
 hidden_size: 512
 num_layers: 2
 dropout: 0.5
+transfer: true
 
 transform:
   type: raw

--- a/autrainer-configurations/model/Whisper-FFNN-Base.yaml
+++ b/autrainer-configurations/model/Whisper-FFNN-Base.yaml
@@ -1,14 +1,13 @@
-id: Whisper-FFNN-Tiny-T
+id: Whisper-FFNN-Base
 _target_: autrainer.models.WhisperFFNN
-model_name: openai/whisper-tiny
+model_name: openai/whisper-base
 hidden_size: 512
 num_layers: 2
 dropout: 0.5
-transfer: true
 
 transform:
   type: raw
   base:
     - autrainer.transforms.FeatureExtractor:
         fe_type: Whisper
-        fe_transfer: openai/whisper-tiny
+        fe_transfer: openai/whisper-base

--- a/autrainer-configurations/model/Whisper-FFNN-Small-T.yaml
+++ b/autrainer-configurations/model/Whisper-FFNN-Small-T.yaml
@@ -4,6 +4,7 @@ model_name: openai/whisper-small
 hidden_size: 512
 num_layers: 2
 dropout: 0.5
+transfer: true
 
 transform:
   type: raw

--- a/autrainer-configurations/model/Whisper-FFNN-Small.yaml
+++ b/autrainer-configurations/model/Whisper-FFNN-Small.yaml
@@ -1,14 +1,13 @@
-id: Whisper-FFNN-Tiny-T
+id: Whisper-FFNN-Small
 _target_: autrainer.models.WhisperFFNN
-model_name: openai/whisper-tiny
+model_name: openai/whisper-small
 hidden_size: 512
 num_layers: 2
 dropout: 0.5
-transfer: true
 
 transform:
   type: raw
   base:
     - autrainer.transforms.FeatureExtractor:
         fe_type: Whisper
-        fe_transfer: openai/whisper-tiny
+        fe_transfer: openai/whisper-small

--- a/autrainer-configurations/model/Whisper-FFNN-Tiny.yaml
+++ b/autrainer-configurations/model/Whisper-FFNN-Tiny.yaml
@@ -1,10 +1,9 @@
-id: Whisper-FFNN-Tiny-T
+id: Whisper-FFNN-Tiny
 _target_: autrainer.models.WhisperFFNN
 model_name: openai/whisper-tiny
 hidden_size: 512
 num_layers: 2
 dropout: 0.5
-transfer: true
 
 transform:
   type: raw

--- a/autrainer-configurations/model/w2v2-b-T.yaml
+++ b/autrainer-configurations/model/w2v2-b-T.yaml
@@ -1,0 +1,15 @@
+id: w2v2-b-T
+_target_: autrainer.models.W2V2FFNN
+model_name: facebook/wav2vec2-base
+freeze_extractor: true
+hidden_size: 512
+num_layers: 2
+dropout: 0.5
+transfer: true
+
+transform:
+  type: raw
+  base:
+    - autrainer.transforms.FeatureExtractor:
+        fe_type: W2V2
+        fe_transfer: facebook/wav2vec2-base

--- a/autrainer-configurations/model/w2v2-l-100k-T.yaml
+++ b/autrainer-configurations/model/w2v2-l-100k-T.yaml
@@ -1,0 +1,15 @@
+id: w2v2-l-100k-T
+_target_: autrainer.models.W2V2FFNN
+model_name: facebook/wav2vec2-large-100k-voxpopuli
+freeze_extractor: true
+hidden_size: 512
+num_layers: 2
+dropout: 0.5
+transfer: true
+
+transform:
+  type: raw
+  base:
+    - autrainer.transforms.FeatureExtractor:
+        fe_type: W2V2
+        fe_transfer: facebook/wav2vec2-large-100k-voxpopuli

--- a/autrainer-configurations/model/w2v2-l-T.yaml
+++ b/autrainer-configurations/model/w2v2-l-T.yaml
@@ -1,0 +1,15 @@
+id: w2v2-l-T
+_target_: autrainer.models.W2V2FFNN
+model_name: facebook/wav2vec2-large
+freeze_extractor: true
+hidden_size: 512
+num_layers: 2
+dropout: 0.5
+transfer: true
+
+transform:
+  type: raw
+  base:
+    - autrainer.transforms.FeatureExtractor:
+        fe_type: W2V2
+        fe_transfer: facebook/wav2vec2-large

--- a/autrainer-configurations/model/w2v2-l-emo-T.yaml
+++ b/autrainer-configurations/model/w2v2-l-emo-T.yaml
@@ -1,0 +1,15 @@
+id: w2v2-l-emo-T
+_target_: autrainer.models.W2V2FFNN
+model_name: audeering/wav2vec2-large-robust-12-ft-emotion-msp-dim
+freeze_extractor: true
+hidden_size: 512
+num_layers: 2
+dropout: 0.5
+transfer: true
+
+transform:
+  type: raw
+  base:
+    - autrainer.transforms.FeatureExtractor:
+        fe_type: W2V2
+        fe_transfer: audeering/wav2vec2-large-robust-12-ft-emotion-msp-dim

--- a/autrainer-configurations/model/w2v2-l-rob-T.yaml
+++ b/autrainer-configurations/model/w2v2-l-rob-T.yaml
@@ -1,0 +1,15 @@
+id: w2v2-l-rob-T
+_target_: autrainer.models.W2V2FFNN
+model_name: facebook/wav2vec2-large-robust
+freeze_extractor: true
+hidden_size: 512
+num_layers: 2
+dropout: 0.5
+transfer: true
+
+transform:
+  type: raw
+  base:
+    - autrainer.transforms.FeatureExtractor:
+        fe_type: W2V2
+        fe_transfer: facebook/wav2vec2-large-robust

--- a/autrainer/core/scripts/fetch_script.py
+++ b/autrainer/core/scripts/fetch_script.py
@@ -72,8 +72,10 @@ class FetchScript(AbstractPreprocessScript):
         print("Fetching models...")
         for name, model in self.models.items():
             print(f" - {name}")
+            model_checkpoint = model.pop("model_checkpoint", None)
+            if model_checkpoint:
+                continue  # no need to download if checkpoint is provided
             model.pop("transform", None)
-            model.pop("model_checkpoint", None)
             model.pop("optimizer_checkpoint", None)
             model.pop("scheduler_checkpoint", None)
             model.pop("skip_last_layer", None)

--- a/autrainer/models/abstract_model.py
+++ b/autrainer/models/abstract_model.py
@@ -1,21 +1,29 @@
 from abc import ABC, abstractmethod
 from functools import cached_property
 from inspect import signature
-from typing import List
+from typing import List, Optional, Union
 
 import audobject
 import torch
 
 
 class AbstractModel(torch.nn.Module, audobject.Object, ABC):
-    def __init__(self, output_dim: int) -> None:
+    def __init__(
+        self,
+        output_dim: int,
+        transfer: Optional[Union[bool, str]] = None,
+    ) -> None:
         """Abstract model class.
 
         Args:
             output_dim: Output dimension of the model.
+            transfer: Whether to load the model with pretrained weights if
+                available. May be a boolean or a string representing a truthy
+                or falsy value. Defaults to None.
         """
         super().__init__()
         self.output_dim = output_dim
+        self.transfer = transfer
 
     @abstractmethod
     def embeddings(self, features: torch.Tensor) -> torch.Tensor:
@@ -58,4 +66,4 @@ class AbstractModel(torch.nn.Module, audobject.Object, ABC):
         Returns:
             Model output.
         """
-        raise NotImplementedError
+        raise NotImplementedError  # pragma: no cover

--- a/autrainer/models/ast_model.py
+++ b/autrainer/models/ast_model.py
@@ -30,12 +30,11 @@ class ASTModel(AbstractModel):
                 For more information see:
                 https://huggingface.co/MIT/ast-finetuned-audioset-10-10-0.4593
         """
-        super().__init__(output_dim)
+        super().__init__(output_dim, transfer)
         self.num_hidden_layers = num_hidden_layers
         self.hidden_size = hidden_size
         self.dropout = dropout
-        self.transfer = transfer
-        if self.transfer is not None:
+        if self.transfer:  # pragma: no cover
             self.model = ASTBaseModel.from_pretrained(
                 self.transfer,
                 num_hidden_layers=num_hidden_layers,

--- a/autrainer/models/cnn_10.py
+++ b/autrainer/models/cnn_10.py
@@ -24,12 +24,11 @@ class Cnn10(AbstractModel):
                 Defaults to False.
             in_channels: Number of input channels. Defaults to 1.
             transfer: Link to the weights to transfer. If None, the weights
-                weights will be randomly initialized. Defaults to None.
+                are randomly initialized. Defaults to None.
         """
-        super().__init__(output_dim)
+        super().__init__(output_dim, transfer)
         self.segmentwise = segmentwise
         self.in_channels = in_channels
-        self.transfer = transfer
         self.bn0 = torch.nn.BatchNorm2d(64)
 
         self.conv_block1 = ConvBlock(in_channels=in_channels, out_channels=64)
@@ -41,7 +40,7 @@ class Cnn10(AbstractModel):
         self.out = torch.nn.Linear(512, output_dim, bias=True)
 
         self.init_weight()
-        if self.transfer is not None:
+        if self.transfer:  # pragma: no cover
             load_transfer_weights(self, self.transfer)
 
     def init_weight(self) -> None:

--- a/autrainer/models/cnn_14.py
+++ b/autrainer/models/cnn_14.py
@@ -26,10 +26,9 @@ class Cnn14(AbstractModel):
             transfer: Link to the weights to transfer. If None, the weights
                 weights will be randomly initialized. Defaults to None.
         """
-        super().__init__(output_dim)
+        super().__init__(output_dim, transfer)
         self.segmentwise = segmentwise
         self.in_channels = in_channels
-        self.transfer = transfer
 
         self.bn0 = torch.nn.BatchNorm2d(64)
         self.conv_block1 = ConvBlock(in_channels=in_channels, out_channels=64)
@@ -43,7 +42,7 @@ class Cnn14(AbstractModel):
         self.out = torch.nn.Linear(2048, self.output_dim, bias=True)
 
         self.init_weight()
-        if self.transfer is not None:
+        if self.transfer:  # pragma: no cover
             import numpy as np
             from numpy.core.multiarray import _reconstruct
 

--- a/autrainer/models/end2you.py
+++ b/autrainer/models/end2you.py
@@ -14,7 +14,7 @@ Adapted to match coding styles of current repo:
 
 """
 
-from typing import Tuple
+from typing import Optional, Tuple, Union
 
 import numpy as np
 import torch
@@ -22,6 +22,7 @@ import torch.nn as nn
 
 from .abstract_model import AbstractModel
 from .sequential import Sequential
+from .utils import assert_no_transfer_weights
 
 
 class Base(nn.Module):
@@ -302,6 +303,7 @@ class AudioRNNModel(AbstractModel):
         dropout: float = 0.5,
         cell: str = "LSTM",
         bidirectional: bool = False,
+        transfer: Optional[Union[bool, str]] = None,
     ) -> None:
         """Audio RNN model.
 
@@ -314,8 +316,11 @@ class AudioRNNModel(AbstractModel):
             cell: Type of RNN cell in ["LSTM", "GRU"] Defaults to "LSTM".
             bidirectional: Whether to use a bidirectional RNN.
                 Defaults to False.
+            transfer: Not available for this model. If set, raises an error.
+                Defaults to None.
         """
-        super().__init__(output_dim)
+        assert_no_transfer_weights(self, transfer)
+        super().__init__(output_dim, None)  # no transfer learning weights
         self.model_name = model_name
         self.hidden_size = hidden_size
         self.num_layers = num_layers

--- a/autrainer/models/ffnn.py
+++ b/autrainer/models/ffnn.py
@@ -1,7 +1,9 @@
+from typing import Optional, Union
+
 import torch
 
 from .abstract_model import AbstractModel
-from .utils import ExtractLayerEmbeddings
+from .utils import ExtractLayerEmbeddings, assert_no_transfer_weights
 
 
 class FFNN(AbstractModel):
@@ -12,6 +14,7 @@ class FFNN(AbstractModel):
         hidden_size: int,
         num_layers: int = 2,
         dropout: float = 0.5,
+        transfer: Optional[Union[bool, str]] = None,
     ) -> None:
         """Feedforward neural network.
 
@@ -21,8 +24,11 @@ class FFNN(AbstractModel):
             hidden_size: Hidden size.
             num_layers: Number of layers.
             dropout: Dropout rate.
+            transfer: Not available for this model. If set, raises an error.
+                Defaults to None.
         """
-        super().__init__(output_dim)
+        assert_no_transfer_weights(self, transfer)
+        super().__init__(output_dim, None)  # no transfer learning weights
         self.input_size = input_size
         self.hidden_size = hidden_size
         self.num_layers = num_layers

--- a/autrainer/models/leaf.py
+++ b/autrainer/models/leaf.py
@@ -69,7 +69,7 @@ class LEAFNet(AbstractModel):
             ValueError: If efficientnet_type is not supported.
             ValueError: If mode is not supported.
         """
-        super().__init__(output_dim)
+        super().__init__(output_dim, transfer)
         # convert LEAF params from ms to samples
         self.mode = mode
         self.initialization = initialization
@@ -83,7 +83,6 @@ class LEAFNet(AbstractModel):
         self.window_stride = window_stride
         self.padding_kernel_size = padding_kernel_size
         self.efficientnet_type = efficientnet_type
-        self.transfer = transfer
         kernel_size_sample = int(sample_rate * kernel_size / 1000)
         kernel_size_sample += 1 - (kernel_size % 2)  # make odd
 

--- a/autrainer/models/sequential.py
+++ b/autrainer/models/sequential.py
@@ -1,7 +1,10 @@
+from typing import Optional, Union
+
 import torch
 
 from .abstract_model import AbstractModel
 from .ffnn import FFNN
+from .utils import assert_no_transfer_weights
 
 
 class Sequential(AbstractModel):
@@ -14,9 +17,12 @@ class Sequential(AbstractModel):
         cell: str = "LSTM",
         time_pooling: bool = True,
         bidirectional: bool = False,
+        transfer: Optional[Union[bool, str]] = None,
     ):
+        assert_no_transfer_weights(self, transfer)
         super().__init__(
-            output_dim=2 * hidden_size if bidirectional else hidden_size
+            output_dim=2 * hidden_size if bidirectional else hidden_size,
+            transfer=None,  # no transfer learning weights
         )
         self.input_dim = input_dim
         self.hidden_size = hidden_size
@@ -61,6 +67,7 @@ class SeqFFNN(AbstractModel):
         backbone_cell: str = "LSTM",
         backbone_time_pooling: bool = True,
         backbone_bidirectional: bool = False,
+        transfer: Optional[Union[bool, str]] = None,
     ):
         """Sequential model with FFNN frontend.
 
@@ -79,8 +86,11 @@ class SeqFFNN(AbstractModel):
                 backbone. Defaults to True.
             backbone_bidirectional: Whether to use a bidirectional backbone.
                 Defaults to False.
+            transfer: Not available for this model. If set, raises an error.
+                Defaults to None.
         """
-        super().__init__(output_dim)
+        assert_no_transfer_weights(self, transfer)
+        super().__init__(output_dim, None)  # no transfer learning weights
         self.backbone_input_dim = backbone_input_dim
         self.backbone_hidden_size = backbone_hidden_size
         self.backbone_num_layers = backbone_num_layers

--- a/autrainer/models/tdnn.py
+++ b/autrainer/models/tdnn.py
@@ -1,7 +1,6 @@
 import os
 import warnings
 
-from speechbrain.inference.classifiers import EncoderClassifier
 import torch
 
 from .abstract_model import AbstractModel
@@ -15,6 +14,7 @@ class TDNNFFNN(AbstractModel):
         hidden_size: int,
         num_layers: int = 2,
         dropout: float = 0.5,
+        transfer: bool = False,
     ) -> None:
         """Time Delay Neural Network with FFNN frontend.
 
@@ -23,24 +23,42 @@ class TDNNFFNN(AbstractModel):
             hidden_size: Hidden size.
             num_layers: Number of layers. Defaults to 2.
             dropout: Dropout rate. Defaults to 0.5.
+            transfer: Whether to initialize the TDNN backbone with
+                pretrained weights. Defaults to False.
         """
-        super().__init__(output_dim)
+        super().__init__(output_dim, transfer)  # no transfer learning weights
         self.hidden_size = hidden_size
         self.num_layers = num_layers
         self.dropout = dropout
-        checkpoint_dir = os.path.join(torch.hub.get_dir(), "speechbrain")
-        os.makedirs(checkpoint_dir, exist_ok=True)
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", category=FutureWarning)
-            tdnn = EncoderClassifier.from_hparams(
-                source="speechbrain/spkrec-ecapa-voxceleb",
-                freeze_params=False,
-                savedir=checkpoint_dir,
-            )
-        self.backbone = tdnn.mods["embedding_model"]
-        self.features = tdnn.mods["compute_features"]
+            if transfer:  # pragma: no cover
+                checkpoint_dir = os.path.join(
+                    torch.hub.get_dir(), "speechbrain"
+                )
+                os.makedirs(checkpoint_dir, exist_ok=True)
+                from speechbrain.inference.classifiers import EncoderClassifier
+
+                tdnn = EncoderClassifier.from_hparams(
+                    source="speechbrain/spkrec-ecapa-voxceleb",
+                    freeze_params=False,
+                    savedir=checkpoint_dir,
+                )
+                self.features = tdnn.mods["compute_features"]
+                self.backbone = tdnn.mods["embedding_model"]
+            else:
+                from speechbrain.lobes.features import Fbank
+                from speechbrain.lobes.models.ECAPA_TDNN import ECAPA_TDNN
+
+                # taken from https://huggingface.co/speechbrain/spkrec-ecapa-voxceleb/blob/main/hyperparams.yaml
+                self.features = Fbank(n_mels=80)
+                self.backbone = ECAPA_TDNN(
+                    input_size=80,
+                    channels=[1024, 1024, 1024, 1024, 3072],
+                )
+
         self.frontend = FFNN(
-            input_size=192,  # TODO: get from model?
+            input_size=list(self.backbone.modules())[-1].weight.shape[0],
             hidden_size=hidden_size,
             output_dim=output_dim,
             num_layers=num_layers,

--- a/autrainer/models/timm_wrapper.py
+++ b/autrainer/models/timm_wrapper.py
@@ -12,7 +12,7 @@ class TimmModel(AbstractModel):
         self,
         output_dim: int,
         timm_name: str,
-        transfer=False,
+        transfer: bool = False,
         **kwargs,
     ) -> None:
         """Wrapper for timm models.
@@ -25,9 +25,8 @@ class TimmModel(AbstractModel):
                 output features. Defaults to False.
             kwargs: Additional arguments to pass to the model constructor.
         """
-        super().__init__(output_dim)
+        super().__init__(output_dim, transfer)
         self.timm_name = timm_name
-        self.transfer = transfer
         for key, value in kwargs.items():
             setattr(self, key, value)
 

--- a/autrainer/models/torchvision_wrapper.py
+++ b/autrainer/models/torchvision_wrapper.py
@@ -12,7 +12,7 @@ class TorchvisionModel(AbstractModel):
         self,
         output_dim: int,
         torchvision_name: str,
-        transfer=False,
+        transfer: bool = False,
         **kwargs,
     ) -> None:
         """Wrapper for torchvision models.
@@ -27,13 +27,12 @@ class TorchvisionModel(AbstractModel):
                 output features. Defaults to False.
             kwargs: Additional arguments to pass to the model constructor.
         """
-        super().__init__(output_dim)
+        super().__init__(output_dim, transfer)
         self.torchvision_name = torchvision_name
-        self.transfer = transfer
         for key, value in kwargs.items():
             setattr(self, key, value)  # pragma: no cover
 
-        if transfer:
+        if transfer:  # pragma: no cover
             self.model = torchvision.models.get_model(
                 torchvision_name,
                 weights="DEFAULT",

--- a/autrainer/models/utils.py
+++ b/autrainer/models/utils.py
@@ -1,5 +1,5 @@
 import os
-from typing import Callable, Dict, List, Union
+from typing import Callable, Dict, List, Optional, Union
 import warnings
 
 import requests
@@ -200,3 +200,15 @@ def create_model_inputs(
         if key not in _forbidden and key in model.inputs:
             model_inputs[key] = value
     return model_inputs
+
+
+def assert_no_transfer_weights(
+    model: AbstractModel,
+    transfer: Optional[Union[bool, str]] = None,
+) -> None:
+    if not transfer:
+        return
+    raise ValueError(
+        f"Model '{type(model).__name__}' does not support "
+        f"transfer='{transfer}'. Set transfer to 'False' or 'None'. "
+    )

--- a/autrainer/models/whisper.py
+++ b/autrainer/models/whisper.py
@@ -1,15 +1,30 @@
+import warnings
+
 import torch
-from transformers import WhisperModel
+from transformers import WhisperConfig, WhisperModel
 
 from .abstract_model import AbstractModel
 from .ffnn import FFNN
 
 
 class WhisperBackbone(AbstractModel):
-    def __init__(self, model_name: str) -> None:
+    def __init__(self, model_name: str, transfer: bool = False) -> None:
         self.model_name = model_name
-        model = WhisperModel.from_pretrained(self.model_name)
-        super().__init__(output_dim=model.config.hidden_size)
+        with warnings.catch_warnings():
+            warnings.simplefilter("ignore")
+            if transfer:  # pragma: no cover
+                model = WhisperModel.from_pretrained(self.model_name)
+            else:
+                config = WhisperConfig.from_pretrained(
+                    self.model_name,
+                    output_hidden_states=True,
+                    return_dict=True,
+                )
+                model = WhisperModel(config)
+        super().__init__(
+            output_dim=model.config.hidden_size,
+            transfer=transfer,
+        )
         self.model = model
         self.register_buffer(
             "decoder_input_ids",
@@ -35,6 +50,7 @@ class WhisperFFNN(AbstractModel):
         hidden_size: int,
         num_layers: int = 2,
         dropout: float = 0.5,
+        transfer: bool = False,
     ) -> None:
         """Whisper model with FFNN frontend adapted for audio classification.
         For more information, see:
@@ -46,13 +62,15 @@ class WhisperFFNN(AbstractModel):
             output_dim: Output dimension of the FFNN.
             num_layers: Number of layers of the FFNN. Defaults to 2.
             dropout: Dropout rate. Defaults to 0.5.
+            transfer: Whether to initialize the Whisper backbone with
+                pretrained weights. Defaults to False.
         """
-        super().__init__(output_dim)
+        super().__init__(output_dim, transfer)
         self.model_name = model_name
         self.hidden_size = hidden_size
         self.num_layers = num_layers
         self.dropout = dropout
-        self.backbone = WhisperBackbone(model_name=model_name)
+        self.backbone = WhisperBackbone(model_name, transfer)
         self.frontend = FFNN(
             input_size=self.backbone.output_dim,
             hidden_size=hidden_size,

--- a/autrainer/serving/serving.py
+++ b/autrainer/serving/serving.py
@@ -67,7 +67,8 @@ class Inference:
         sys.path.append(os.getcwd())
 
         self.model: AbstractModel = audobject.from_yaml(
-            os.path.join(self._model_path, "model.yaml")
+            os.path.join(self._model_path, "model.yaml"),
+            override_args={"transfer": None},
         )
         with warnings.catch_warnings():
             warnings.simplefilter("ignore", UserWarning)

--- a/autrainer/training/training.py
+++ b/autrainer/training/training.py
@@ -135,6 +135,8 @@ class ModularTaskTrainer:
 
         # ? Load Pretrained Model, Optimizer, and Scheduler Checkpoints
         model_checkpoint = model_config.pop("model_checkpoint", None)
+        if model_checkpoint and model_config.get("transfer", None):
+            model_config.pop("transfer", None)  # skip transfer for checkpoints
         optimizer_checkpoint = model_config.pop("optimizer_checkpoint", None)
         scheduler_checkpoint = model_config.pop("scheduler_checkpoint", None)
         skip_last_layer = model_config.pop("skip_last_layer", True)

--- a/docs/source/examples/tutorials/multi_branch_model.py
+++ b/docs/source/examples/tutorials/multi_branch_model.py
@@ -5,7 +5,7 @@ from autrainer.models import AbstractModel
 
 class ToyMultiBranchModel(AbstractModel):
     def __init__(self, input_dim: int, output_dim: int, hidden_dim: int):
-        super().__init__(output_dim)
+        super().__init__(output_dim, None)  # no transfer learning
         self.input_dim = input_dim
         self.hidden_dim = hidden_dim
 

--- a/docs/source/examples/tutorials/spectrogram_cnn.py
+++ b/docs/source/examples/tutorials/spectrogram_cnn.py
@@ -13,7 +13,7 @@ class SpectrogramCNN(AbstractModel):
             output_dim: Output dimension of the model.
             hidden_dims: List of hidden dimensions for the CNN layers.
         """
-        super().__init__(output_dim)
+        super().__init__(output_dim, None)  # no transfer learning
         self.hidden_dims = hidden_dims
         layers = []
         input_dim = 1


### PR DESCRIPTION
Closes #29 by adding a `transfer` argument to all models. This allows for handling the transfer argument as follows:
- `autrainer fetch` and `autrainer train`: remove `transfer` if a model checkpoint is provided -> no weights need to be downloaded
- `autrainer inference`: override `transfer` to `None` as we will always load a checkpoint

Testability to verify this functionality is very limited and still kinda up to debate. Of course i checked everything manually but i dont have a good automated solution to do so right now.

### Additional changes
- This adds the `transfer` functionality to all our models, allowing to load all of them with pretrained weights. The only exceptions are `AudioRNNModel`, `FFNN`, and `SeqFFNN`. These will raise an error when you pass a truthy value for `transfer`. The reason they also have this argument now it to have a uniform interface for `AbstractModel`.

- Since we now have the ability to load all models with `transfer=None`, most tests will do so, mostly resolving the issue that tests may fail due to downloading model states here: https://github.com/autrainer/autrainer/pull/46#issuecomment-2752115788
For `TorchvisionModel`, we still keep the transfer test as `efficientnet_b0` is a small model state and verifies that overriding the last layer works.

### Breaking changes
Whisper, TDNN, and W2V2 models can now be initialized with random weights, so all of their pretrained-configs (ending with `-T`) were either newly created or include `transfer: true` now.