### PR TITLE
Fix Missing Transform Download during Fetch

### DIFF
--- a/autrainer/core/scripts/fetch_script.py
+++ b/autrainer/core/scripts/fetch_script.py
@@ -23,7 +23,7 @@ class FetchScript(AbstractPreprocessScript):
         super().__init__(
             "fetch",
             (
-                "Fetch the datasets and models specified in a "
+                "Fetch the datasets, models, and transforms specified in a "
                 "training configuration (Hydra)."
             ),
             extended_description=(
@@ -101,7 +101,8 @@ def fetch(
     config_name: str = "config",
     config_path: Optional[str] = None,
 ) -> None:
-    """Fetch the datasets and models specified in a training configuration.
+    """Fetch the datasets, models, and transforms specified in a training
+    configuration.
 
     Args:
         override_kwargs: Additional Hydra override arguments to pass to the

--- a/autrainer/core/scripts/fetch_script.py
+++ b/autrainer/core/scripts/fetch_script.py
@@ -67,17 +67,31 @@ class FetchScript(AbstractPreprocessScript):
                     "path": dataset["path"],
                 },
             )  # pragma: no cover
+            self._download_transform(dataset.get("transform", None))
 
     def _download_models(self) -> None:
         print("Fetching models...")
         for name, model in self.models.items():
             print(f" - {name}")
-            model.pop("transform", None)
+            self._download_transform(model.pop("transform", None))
             model.pop("model_checkpoint", None)
             model.pop("optimizer_checkpoint", None)
             model.pop("scheduler_checkpoint", None)
             model.pop("skip_last_layer", None)
             autrainer.instantiate(config=model, output_dim=10)
+
+    def _download_transform(self, transform: Optional[DictConfig]) -> None:
+        if not transform:
+            return
+        from autrainer.transforms import TransformManager
+
+        for subset in ["base", "train", "dev", "test"]:
+            if (transforms := transform.get(subset, None)) is None:
+                continue
+            for t in transforms:
+                if isinstance(t, dict) and next(iter(t.values())) is None:
+                    continue  # skip removed transforms
+                TransformManager._instantiate(t)
 
 
 @catch_cli_errors

--- a/docs/source/modules/transforms.rst
+++ b/docs/source/modules/transforms.rst
@@ -22,6 +22,12 @@ or custom transforms inheriting from the :class:`AbstractTransform` class.
 While the choice to use offline or online transforms depends on the use case and is a tradeoff between storage and computational costs,
 both can be used in conjunction for maximum flexibility.
 
+.. note::
+
+   Some transforms (such as :class:`~autrainer.transforms.FeatureExtractor`) may require additional resources
+   (e.g., tokenizers), which can be automatically downloaded using the :ref:`autrainer fetch <cli_autrainer_fetch>` CLI command
+   or the :meth:`~autrainer.cli.fetch` CLI wrapper function after specifying the transform in the model or dataset configuration.
+
 
 .. _preprocessing_transforms:
 

--- a/docs/source/usage/cli_reference.rst
+++ b/docs/source/usage/cli_reference.rst
@@ -107,7 +107,7 @@ Preprocessing
 
 To avoid race conditions when using :ref:`hydra_launcher_plugins` that may run multiple training jobs in parallel,
 :ref:`autrainer fetch <cli_autrainer_fetch>` and :ref:`autrainer preprocess <cli_autrainer_preprocess>` allow for
-downloading and :ref:`preprocessing <preprocessing_transforms>` of :ref:`datasets` (and pretrained model states) before training.
+downloading and :ref:`preprocessing <preprocessing_transforms>` of :ref:`datasets` (and pretrained model states or transforms) before training.
 
 Both commands are based on the :ref:`main configuration <main_configuration>` file (e.g., :file:`conf/config.yaml`),
 such that the specified models and datasets are fetched and preprocessed accordingly.

--- a/docs/source/usage/cli_wrapper.rst
+++ b/docs/source/usage/cli_wrapper.rst
@@ -51,7 +51,7 @@ Preprocessing
 
 To avoid race conditions when using :ref:`hydra_launcher_plugins` that may run multiple training jobs in parallel,
 :meth:`~autrainer.cli.fetch` and :meth:`~autrainer.cli.preprocess` allow for
-downloading and :ref:`preprocessing <preprocessing_transforms>` of :ref:`datasets` (and pretrained model states) before training.
+downloading and :ref:`preprocessing <preprocessing_transforms>` of :ref:`datasets` (and pretrained model states or transforms) before training.
 
 Both commands are based on the :ref:`main configuration <main_configuration>` file (e.g., :file:`conf/config.yaml`),
 such that the specified models and datasets are fetched and preprocessed accordingly.


### PR DESCRIPTION
This fixes a potential race condition when transforms require additional stuff being downloaded before training, such as any feature extractor that is downloading a tokenizer. Therefore we can just instantiate the transform (analogous to what we do during fetching the model).