### PR TITLE
Fix Incorrect Optimizer Device during State Loading

### DIFF
--- a/autrainer/training/training.py
+++ b/autrainer/training/training.py
@@ -176,7 +176,7 @@ class ModularTaskTrainer:
         if optimizer_checkpoint:
             state_dict = torch.load(
                 optimizer_checkpoint,
-                map_location="cpu",
+                map_location=self.DEVICE,
                 weights_only=True,
             )
             load_pretrained_optim_state(


### PR DESCRIPTION
This fixes a device mismatch when an optimizer state dict is loaded and its state does not match the device by directly moving the state dict.