### PR TITLE
Fix Augmentation Generator Offsets

### DIFF
--- a/autrainer/augmentations/augmentation_pipeline.py
+++ b/autrainer/augmentations/augmentation_pipeline.py
@@ -4,6 +4,7 @@ import autrainer
 from autrainer.transforms import SmartCompose
 
 from .abstract_augmentation import AbstractAugmentation
+from .utils import assign_seeds, convert_shorthand
 
 
 class AugmentationPipeline:
@@ -26,14 +27,10 @@ class AugmentationPipeline:
         """
         self.generator_seed = generator_seed
         self.pipeline = []
+        current_seed = generator_seed
         for aug in pipeline:
-            if isinstance(aug, str):
-                aug = {aug: {}}  # convert to shorthand syntax
-            aug_name = next(iter(aug.keys()))
-            if aug[aug_name].get("generator_seed") is None:
-                aug[aug_name]["generator_seed"] = generator_seed
-                if increment:
-                    generator_seed += 1
+            aug = convert_shorthand(aug)
+            aug, current_seed = assign_seeds(aug, current_seed, increment)
             self.pipeline.append(aug)
 
         self.pipeline: List[AbstractAugmentation] = [

--- a/autrainer/augmentations/choice_augmentation.py
+++ b/autrainer/augmentations/choice_augmentation.py
@@ -91,3 +91,8 @@ class Choice(AbstractAugmentation, audobject.Object):
         weights = torch.Tensor(self.weights)
         choice = torch.multinomial(weights, 1, generator=self.g).item()
         return self.augmentation_choices[choice](item)
+
+    @property
+    def _deterministic(self) -> bool:
+        """Return True if the augmentation is deterministic, False otherwise."""
+        return all(aug._deterministic for aug in self.augmentation_choices)

--- a/autrainer/augmentations/choice_augmentation.py
+++ b/autrainer/augmentations/choice_augmentation.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from typing import Dict, List, Optional
 
 import audobject
@@ -7,6 +8,7 @@ import autrainer
 from autrainer.core.structs import AbstractDataItem
 
 from .abstract_augmentation import AbstractAugmentation
+from .utils import convert_shorthand
 
 
 class Choice(AbstractAugmentation, audobject.Object):
@@ -51,16 +53,12 @@ class Choice(AbstractAugmentation, audobject.Object):
         self.choices = choices
         self.augmentation_choices = []
 
-        for aug in self.choices:
-            if isinstance(aug, str):
-                self.augmentation_choices.append(
-                    {aug: {"generator_seed": self.generator_seed}}
-                )
-            else:
-                aug_name = next(iter(aug.keys()))
-                if aug[aug_name].get("generator_seed") is None:
-                    aug[aug_name]["generator_seed"] = self.generator_seed
-                self.augmentation_choices.append(aug)
+        for aug in deepcopy(self.choices):
+            aug = convert_shorthand(aug)
+            aug_name = next(iter(aug.keys()))
+            if aug[aug_name].get("generator_seed") is None:
+                aug[aug_name]["generator_seed"] = self.generator_seed
+            self.augmentation_choices.append(aug)
 
         self.augmentation_choices: List[AbstractAugmentation] = [
             autrainer.instantiate_shorthand(

--- a/autrainer/augmentations/choice_augmentation.py
+++ b/autrainer/augmentations/choice_augmentation.py
@@ -67,7 +67,7 @@ class Choice(AbstractAugmentation, audobject.Object):
                 choice,
                 instance_of=AbstractAugmentation,
             )
-            for choice in self.choices
+            for choice in self.augmentation_choices
         ]
         for aug in self.augmentation_choices:
             if hasattr(aug, "get_collate_fn"):

--- a/autrainer/augmentations/choice_augmentation.py
+++ b/autrainer/augmentations/choice_augmentation.py
@@ -73,6 +73,11 @@ class Choice(AbstractAugmentation, audobject.Object):
                     "Choice augmentations must not have a collate function."
                 )
 
+    def offset_generator_seed(self, offset: int) -> None:
+        super().offset_generator_seed(offset)
+        for aug in self.augmentation_choices:
+            aug.offset_generator_seed(offset)
+
     def apply(self, item: AbstractDataItem) -> AbstractDataItem:
         """Choose one augmentation from the list of augmentations based on the
         given weights.

--- a/autrainer/augmentations/sequential_augmentation.py
+++ b/autrainer/augmentations/sequential_augmentation.py
@@ -56,7 +56,7 @@ class Sequential(AbstractAugmentation, audobject.Object):
                 aug,
                 instance_of=AbstractAugmentation,
             )
-            for aug in self.sequence
+            for aug in self.augmentation_sequence
         ]
         for aug in self.augmentation_sequence:
             if hasattr(aug, "get_collate_fn"):

--- a/autrainer/augmentations/sequential_augmentation.py
+++ b/autrainer/augmentations/sequential_augmentation.py
@@ -79,3 +79,8 @@ class Sequential(AbstractAugmentation, audobject.Object):
         for aug in self.augmentation_sequence:
             item = aug(item)
         return item
+
+    @property
+    def _deterministic(self) -> bool:
+        """Return True if the augmentation is deterministic, False otherwise."""
+        return all(aug._deterministic for aug in self.augmentation_sequence)

--- a/autrainer/augmentations/sequential_augmentation.py
+++ b/autrainer/augmentations/sequential_augmentation.py
@@ -62,6 +62,11 @@ class Sequential(AbstractAugmentation, audobject.Object):
                     "Choice augmentations must not have a collate function."
                 )
 
+    def offset_generator_seed(self, offset: int) -> None:
+        super().offset_generator_seed(offset)
+        for aug in self.augmentation_sequence:
+            aug.offset_generator_seed(offset)
+
     def apply(self, item: AbstractDataItem) -> AbstractDataItem:
         """Apply all augmentations in sequence to the input tensor.
 

--- a/autrainer/augmentations/sequential_augmentation.py
+++ b/autrainer/augmentations/sequential_augmentation.py
@@ -1,3 +1,4 @@
+from copy import deepcopy
 from typing import Dict, List, Optional
 
 import audobject
@@ -6,6 +7,7 @@ import autrainer
 from autrainer.core.structs import AbstractDataItem
 
 from .abstract_augmentation import AbstractAugmentation
+from .utils import convert_shorthand
 
 
 class Sequential(AbstractAugmentation, audobject.Object):
@@ -40,16 +42,12 @@ class Sequential(AbstractAugmentation, audobject.Object):
         self.sequence = sequence
         self.augmentation_sequence = []
 
-        for aug in self.sequence:
-            if isinstance(aug, str):
-                self.augmentation_sequence.append(
-                    {aug: {"generator_seed": self.generator_seed}}
-                )
-            else:
-                aug_name = next(iter(aug.keys()))
-                if aug[aug_name].get("generator_seed") is None:
-                    aug[aug_name]["generator_seed"] = self.generator_seed
-                self.augmentation_sequence.append(aug)
+        for aug in deepcopy(self.sequence):
+            aug = convert_shorthand(aug)
+            aug_name = next(iter(aug.keys()))
+            if aug[aug_name].get("generator_seed") is None:
+                aug[aug_name]["generator_seed"] = self.generator_seed
+            self.augmentation_sequence.append(aug)
 
         self.augmentation_sequence: List[AbstractAugmentation] = [
             autrainer.instantiate_shorthand(

--- a/autrainer/augmentations/utils.py
+++ b/autrainer/augmentations/utils.py
@@ -1,0 +1,54 @@
+from typing import Any, Dict, Tuple, Union
+
+
+def convert_shorthand(aug: Union[str, Dict[str, Any]]) -> Dict[str, Any]:
+    """Convert shorthand syntax to a dictionary.
+
+    Args:
+        aug: The augmentation to convert.
+
+    Returns:
+        The converted augmentation.
+    """
+    if isinstance(aug, str):
+        return {aug: {}}
+    return aug
+
+
+def assign_seeds(
+    aug: Dict[str, Any],
+    current_seed: int,
+    increment: bool,
+) -> Tuple[Dict[str, Any], int]:
+    aug_name = next(iter(aug))
+    config = aug[aug_name]
+
+    if "generator_seed" not in config or config["generator_seed"] is None:
+        config["generator_seed"] = current_seed
+        if increment:
+            current_seed += 1
+
+    if aug_name == "autrainer.augmentations.Choice" and "choices" in config:
+        new_choices = []
+        for choice in config["choices"]:
+            choice = convert_shorthand(choice)
+            updated_choice, current_seed = assign_seeds(
+                choice, current_seed, increment
+            )
+            new_choices.append(updated_choice)
+        config["choices"] = new_choices
+
+    elif (
+        aug_name == "autrainer.augmentations.Sequential"
+        and "sequence" in config
+    ):
+        new_sequence = []
+        for seq_aug in config["sequence"]:
+            seq_aug = convert_shorthand(seq_aug)
+            updated_aug, current_seed = assign_seeds(
+                seq_aug, current_seed, increment
+            )
+            new_sequence.append(updated_aug)
+        config["sequence"] = new_sequence
+
+    return {aug_name: config}, current_seed

--- a/autrainer/datasets/abstract_dataset.py
+++ b/autrainer/datasets/abstract_dataset.py
@@ -273,7 +273,6 @@ class AbstractDataset(ABC):
         drop_last: bool = False,
         timeout: float = 0,
         prefetch_factor: Optional[int] = None,
-        persistent_workers: bool = False,
         pin_memory_device: str = "",
     ) -> DataLoader:
         self.train_transform.setup(self)
@@ -293,7 +292,7 @@ class AbstractDataset(ABC):
             drop_last=drop_last,
             timeout=timeout,
             prefetch_factor=prefetch_factor,
-            persistent_workers=persistent_workers,
+            persistent_workers=True if num_workers > 0 else False,
             pin_memory_device=pin_memory_device,
         )
 
@@ -305,7 +304,6 @@ class AbstractDataset(ABC):
         drop_last: bool = False,
         timeout: float = 0,
         prefetch_factor: Optional[int] = None,
-        persistent_workers: bool = False,
         pin_memory_device: str = "",
     ) -> DataLoader:
         self.dev_transform.setup(self)
@@ -325,7 +323,7 @@ class AbstractDataset(ABC):
             drop_last=drop_last,
             timeout=timeout,
             prefetch_factor=prefetch_factor,
-            persistent_workers=persistent_workers,
+            persistent_workers=True if num_workers > 0 else False,
             pin_memory_device=pin_memory_device,
         )
 
@@ -337,7 +335,6 @@ class AbstractDataset(ABC):
         drop_last: bool = False,
         timeout: float = 0,
         prefetch_factor: Optional[int] = None,
-        persistent_workers: bool = False,
         pin_memory_device: str = "",
     ) -> DataLoader:
         self.test_transform.setup(self)
@@ -357,7 +354,7 @@ class AbstractDataset(ABC):
             drop_last=drop_last,
             timeout=timeout,
             prefetch_factor=prefetch_factor,
-            persistent_workers=persistent_workers,
+            persistent_workers=True if num_workers > 0 else False,
             pin_memory_device=pin_memory_device,
         )
 

--- a/docs/source/examples/tutorials/cut_mix_up.py
+++ b/docs/source/examples/tutorials/cut_mix_up.py
@@ -34,7 +34,7 @@ class CutMixUp(AbstractAugmentation):
         super().__init__(order, p, generator_seed)
         self.alpha = alpha
         self.cut_mix_up_g = torch.Generator()
-        if generator_seed:
+        if generator_seed is not None:
             self.cut_mix_up_g.manual_seed(generator_seed)
 
     def get_collate_fn(

--- a/docs/source/examples/tutorials/random_scaled_sgd.py
+++ b/docs/source/examples/tutorials/random_scaled_sgd.py
@@ -29,7 +29,7 @@ class RandomScaledSGD(torch.optim.Optimizer):
         self.p = p
         self.g = torch.Generator()
         self.base_lr = self.param_groups[0]["lr"]
-        if generator_seed:
+        if generator_seed is not None:
             self.g.manual_seed(generator_seed)
 
     def custom_step(

--- a/tests/test_augmentations.py
+++ b/tests/test_augmentations.py
@@ -258,11 +258,45 @@ class TestChoice:
         with pytest.raises(ValueError):
             Choice(choices=["autrainer.augmentations.CutMix"])
 
+    def test_offset_generator_seed(self) -> None:
+        choice = Choice(
+            choices=[
+                "autrainer.augmentations.GaussianNoise",
+                "autrainer.augmentations.GaussianNoise",
+            ],
+            generator_seed=AUGMENTATION_SEED,
+        )
+        choice.offset_generator_seed(1)
+        assert (
+            choice.generator_seed == AUGMENTATION_SEED + 1
+        ), "Should offset the generator seed"
+        for c in choice.augmentation_choices:
+            assert (
+                c.generator_seed == AUGMENTATION_SEED + 1
+            ), "Should offset the generator seed of the choice"
+
 
 class TestSequential:
     def test_invalid_collate_fn(self) -> None:
         with pytest.raises(ValueError):
             Sequential(sequence=["autrainer.augmentations.CutMix"])
+
+    def test_offset_generator_seed(self) -> None:
+        seq = Sequential(
+            sequence=[
+                "autrainer.augmentations.GaussianNoise",
+                "autrainer.augmentations.GaussianNoise",
+            ],
+            generator_seed=AUGMENTATION_SEED,
+        )
+        seq.offset_generator_seed(1)
+        assert (
+            seq.generator_seed == AUGMENTATION_SEED + 1
+        ), "Should offset the generator seed"
+        for s in seq.augmentation_sequence:
+            assert (
+                s.generator_seed == AUGMENTATION_SEED + 1
+            ), "Should offset the generator seed of the sequence"
 
 
 class TestBaseMixUpCutMix:


### PR DESCRIPTION
Massive fixes regarding the augmentation generator offsets:
- sequential and choice augmentations constructed their sequence and choices from the wrong loop variable
- sequential and choice augmentations were missing a generator offset delegate (also adds relevant tests)
- sequential and choice augmentations were missing a determinism check (only relevant for tests)
- since our augmentation pipeline is a DAG, we need to recursively increment the generator seeds, otherwise e.g. augmentations in a sequence would not be incremented
- some generator seed checks were wrong if the value is anything evaluating to false
- when workers are used they need to be persistent otherwise their generators would be reset and for training this would lead to replaying the same probabilities 