### PR TITLE
add warning when sliding window length exceeds audio duration

### DIFF
--- a/autrainer/serving/serving.py
+++ b/autrainer/serving/serving.py
@@ -369,11 +369,22 @@ class Inference:
             )
         return embedding
 
-    def _create_windows(self, x: torch.Tensor) -> Tuple[int, int, List[int]]:
+    def _create_windows(self, x: torch.Tensor) -> Tuple[int, int, int]:
         w_len = int(self._window_length * self._sample_rate)
         s_len = int(self._stride_length * self._sample_rate)
+
+        if x.shape[1] < w_len:
+            warnings.warn(
+                f"Sliding window length ({self._window_length:.2f}s) is greater "
+                f"than the audio file length ({x.shape[1] / self._sample_rate:.2f}s). "
+                "This may result in zero or incomplete windows.",
+                UserWarning
+            )
+            return w_len, s_len, 0  #you can change 0 with 1 if you want to process it anyway
+
         num_windows = (x.shape[1] - w_len) // s_len + 1
         return w_len, s_len, num_windows
+
 
     def _predict_windowed(
         self,


### PR DESCRIPTION
Add warning in _create_windows for sliding window length exceeding audio duration

- Warns when the sliding window length is greater than the audio file duration during inference.
- Prevents confusion or silent failures by notifying users if the number of windows is zero.
- Allows optionally setting the number of windows to 1 instead of 0 to still process the file.
