### PR TITLE
Fix Inference for Empty or too Short Audios

### DIFF
--- a/autrainer/serving/serving.py
+++ b/autrainer/serving/serving.py
@@ -1,7 +1,7 @@
 import glob
 import os
 import sys
-from typing import Any, Callable, Dict, List, Optional, Tuple, Union
+from typing import Any, Callable, Dict, Optional, Tuple, Union
 import warnings
 
 import audobject
@@ -369,9 +369,11 @@ class Inference:
             )
         return embedding
 
-    def _create_windows(self, x: torch.Tensor) -> Tuple[int, int, List[int]]:
+    def _create_windows(self, x: torch.Tensor) -> Tuple[int, int, int]:
         w_len = int(self._window_length * self._sample_rate)
         s_len = int(self._stride_length * self._sample_rate)
+        if x.shape[1] < w_len:
+            return w_len, s_len, 1  # force a single window if too short
         num_windows = (x.shape[1] - w_len) // s_len + 1
         return w_len, s_len, num_windows
 

--- a/autrainer/serving/serving.py
+++ b/autrainer/serving/serving.py
@@ -122,7 +122,8 @@ class Inference:
     ) -> pd.DataFrame:
         """Obtain the model predictions for all files in a directory.
 
-        If a file is empty, it will be skipped.
+        If an audio is empty, too short, or an error occurs during
+        processing, it will be skipped.
 
         Args:
             directory: Path to the directory containing audio files.
@@ -182,7 +183,8 @@ class Inference:
     ) -> pd.DataFrame:
         """Obtain the model embeddings for all files in a directory.
 
-        If a file is empty, it will be skipped.
+        If an audio is empty, too short, or an error occurs during
+        processing, it will be skipped.
 
         Args:
             directory: Path to the directory containing audio files.
@@ -244,7 +246,8 @@ class Inference:
             Model prediction, output, and probabilties for the file.
             If sliding window inference is used, the prediction is a dictionary
             with the offset as the key.
-            If the file is empty, None is returned.
+            If the audio is empty, too short, or an error occurs during
+            processing, it will be skipped.
         """
         return self._delegate_file(file, self._predict, self._predict_windowed)
 
@@ -260,7 +263,8 @@ class Inference:
         Returns:
             Model embedding for the file. If sliding window inference is used,
             the embedding is a dictionary with the offset as the key.
-            If the file is empty, None is returned.
+            If the audio is empty, too short, or an error occurs during
+            processing, it will be skipped.
         """
         return self._delegate_file(file, self._embed, self._embed_windowed)
 


### PR DESCRIPTION
Closes #155 by explicitly excluding empty audios for both prediction and embedding, as the results wont really make sense.

Also forces a single window in case the audio is shorter than the windows size (as suggested in https://github.com/autrainer/autrainer/pull/158). As this may lead to inference errors in the model (e.g., for models like CNN10) this also gracefully handles any errors encountered during the forward pass of a single audio sample.

Missing
- [x] tests