### PR TITLE
Added LLD_Delta option to OpenSMILE

### DIFF
--- a/autrainer/transforms/specific_transforms.py
+++ b/autrainer/transforms/specific_transforms.py
@@ -690,6 +690,7 @@ class OpenSMILE(AbstractTransform):
         feature_set: str,
         sample_rate: int,
         functionals: bool = False,
+        lld_deltas: bool = False,
         order: int = -80,
     ) -> None:
         """Extract features from an audio signal using openSMILE.
@@ -702,6 +703,8 @@ class OpenSMILE(AbstractTransform):
             feature_set: The feature set to use.
             sample_rate: The sample rate of the audio signal.
             functionals: Whether to use functionals. Defaults to False.
+            lld_deltas: Whether to additionally compute deltas. Only relevant
+                for LLDs. Defaults to False.
             order: The order of the transform in the pipeline. Defaults to -80.
 
         Raises:
@@ -716,6 +719,8 @@ class OpenSMILE(AbstractTransform):
         self.feature_set = feature_set
         self.sample_rate = sample_rate
         self.functionals = functionals
+        self.lld_deltas = lld_deltas
+        self.smile_de = None
         if self.functionals:
             self.smile = opensmile.Smile(self.feature_set)
         else:
@@ -723,8 +728,22 @@ class OpenSMILE(AbstractTransform):
                 self.feature_set,
                 feature_level=opensmile.FeatureLevel.LowLevelDescriptors,
             )
+            if self.lld_deltas and self.feature_set != "eGeMAPSv02":
+                self.smile_de = opensmile.Smile(
+                    self.feature_set,
+                    feature_level=opensmile.FeatureLevel.LowLevelDescriptors_Deltas,
+                )
 
     def __call__(self, item: AbstractDataItem) -> AbstractDataItem:
         it = self.smile.process_signal(item.features, self.sample_rate)
-        item.features = torch.from_numpy(self.smile.to_numpy(it)).squeeze()
+        feats = torch.from_numpy(self.smile.to_numpy(it)).squeeze()
+        if self.smile_de is not None:
+            data_de = self.smile_de.process_signal(
+                item.features, self.sample_rate
+            )
+            data_de = torch.from_numpy(self.smile.to_numpy(data_de)).squeeze()[
+                :, 1:-1
+            ]
+            feats = torch.cat((feats, data_de), axis=-2)
+        item.features = feats
         return item

--- a/tests/test_transforms.py
+++ b/tests/test_transforms.py
@@ -378,22 +378,27 @@ class TestFeatureExtractor:
 
 class TestOpenSMILE:
     @pytest.mark.parametrize(
-        "feature_set, functionals, expected",
+        "feature_set, functionals, lld_deltas, expected",
         [
-            ("ComParE_2016", False, (65, 96)),
-            ("ComParE_2016", True, (6373,)),
-            ("eGeMAPSv02", False, (25, 96)),
-            ("eGeMAPSv02", True, (88,)),
+            ("ComParE_2016", False, False, (65, 96)),
+            ("ComParE_2016", False, True, (130, 96)),
+            ("ComParE_2016", True, False, (6373,)),
+            ("eGeMAPSv02", False, False, (25, 96)),
+            ("eGeMAPSv02", False, True, (25, 96)),
+            ("eGeMAPSv02", True, False, (88,)),
         ],
     )
     def test_opensmile(
         self,
         feature_set: str,
         functionals: bool,
+        lld_deltas: bool,
         expected: Tuple[int, int],
     ) -> None:
         x = DataItem(torch.randn(16000), 0, 0)
-        y = OpenSMILE(feature_set, 16000, functionals=functionals)(x)
+        y = OpenSMILE(
+            feature_set, 16000, functionals=functionals, lld_deltas=lld_deltas
+        )(x)
         assert torch.is_tensor(y.features), "Output should be a tensor"
         assert y.features.shape == torch.Size(
             expected


### PR DESCRIPTION
This adds the option to extract `openSMILE` `delta-llds` along with `llds` and stack them. This is a common use-case for most `openSMILE-based` models that I have also followed in our paper. 