### PR TITLE
Fix Dev Split Seeds for DCASE2018Task3 and DCASE2020Task1A

### DIFF
--- a/autrainer/datasets/dcase_2018_t3.py
+++ b/autrainer/datasets/dcase_2018_t3.py
@@ -76,9 +76,7 @@ class DCASE2018Task3(BaseClassificationDataset):
         """
         self._assert_dev_split(dev_split)
         self.dev_split = dev_split
-        self.dev_split_seed = (
-            dev_split_seed if dev_split_seed is not None else seed
-        )
+        self.dev_split_seed = dev_split_seed if dev_split_seed is not None else seed
         super().__init__(
             path=path,
             features_subdir=features_subdir,

--- a/autrainer/datasets/dcase_2020_t1a.py
+++ b/autrainer/datasets/dcase_2020_t1a.py
@@ -105,9 +105,7 @@ class DCASE2020Task1A(BaseClassificationDataset):
         """
         self._assert_dev_split(dev_split)
         self.dev_split = dev_split
-        self.dev_split_seed = (
-            dev_split_seed if dev_split_seed is not None else seed
-        )
+        self.dev_split_seed = dev_split_seed if dev_split_seed is not None else seed
         self._assert_scene_category(scene_category)
         self.scene_category = scene_category
         self.exclude_cities = exclude_cities


### PR DESCRIPTION
Closes #177 by explicitly checking if `dev_split_seed` instead of just relying on a truthy value.
If `dev_split_seed` was set to zero, the dataset `seed` was always used.